### PR TITLE
Add CI pipeline and improve CLI help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install ruff
+
+      - name: Lint
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Test
+        run: pytest --cov=. --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ pip install -r requirements-dev.txt
 pytest --cov=. --cov-report=term-missing
 ```
 
-69 tests | 99% coverage
+72 tests | 99% coverage

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## v0.2.1 — CI Pipeline and Improved CLI Help (2026-02-25)
+
+### What's New
+
+- **GitHub Actions CI** — Automated testing on push and PR: pytest with coverage, ruff lint, ruff format
+- **Improved CLI help** — `--help` now shows usage examples, config file location, and first-run guidance
+- **3 new tests** for CLI help output validation
+
+### Quality
+
+- 72 tests | 99% coverage
+- CI pipeline: pytest + ruff check + ruff format on Ubuntu / Python 3.12
+
+### Closes
+
+- #2 — CI pipeline
+- #5 — Improved CLI help
+
+---
+
 ## v0.2.0 — Interactive Site Config with XDG Storage (2026-02-25)
 
 ### What's New

--- a/tests/test_wp_publish.py
+++ b/tests/test_wp_publish.py
@@ -1,9 +1,8 @@
 """Tests for wp-publish.py — TDD-equivalent backfill + v0.2.0 site config tests."""
 
-import json
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
@@ -52,13 +51,7 @@ def valid_md_file(tmp_path):
 def minimal_md_file(tmp_path):
     """Markdown file with only required title — no slug or status."""
     md = tmp_path / "minimal.md"
-    md.write_text(
-        "---\n"
-        'title: "Minimal Page"\n'
-        "---\n"
-        "\n"
-        "Content here.\n"
-    )
+    md.write_text('---\ntitle: "Minimal Page"\n---\n\nContent here.\n')
     return md
 
 
@@ -66,13 +59,7 @@ def minimal_md_file(tmp_path):
 def no_title_md_file(tmp_path):
     """Markdown file missing the required title field."""
     md = tmp_path / "no-title.md"
-    md.write_text(
-        "---\n"
-        'slug: "oops"\n'
-        "---\n"
-        "\n"
-        "No title.\n"
-    )
+    md.write_text('---\nslug: "oops"\n---\n\nNo title.\n')
     return md
 
 
@@ -150,7 +137,9 @@ class TestLoadConfig:
         monkeypatch.delenv("WP_SITE_URL", raising=False)
         monkeypatch.delenv("WP_USER", raising=False)
         monkeypatch.delenv("WP_APP_PASSWORD", raising=False)
-        site_url, user, password = wp_publish.load_config(env_path=str(valid_env_file / ".env"))
+        site_url, user, password = wp_publish.load_config(
+            env_path=str(valid_env_file / ".env")
+        )
         assert site_url == "https://example.com"
         assert user == "testuser"
         assert password == "xxxx xxxx xxxx xxxx"
@@ -224,12 +213,7 @@ class TestParsePage:
         """parse_page exits 1 when frontmatter has invalid status."""
         md = tmp_path / "bad-status.md"
         md.write_text(
-            "---\n"
-            'title: "Bad Status"\n'
-            "status: publis\n"
-            "---\n"
-            "\n"
-            "Typo in status.\n"
+            '---\ntitle: "Bad Status"\nstatus: publis\n---\n\nTypo in status.\n'
         )
         with pytest.raises(SystemExit) as exc_info:
             wp_publish.parse_page(str(md))
@@ -239,12 +223,7 @@ class TestParsePage:
         """parse_page accepts 'publish' as a valid status."""
         md = tmp_path / "publish.md"
         md.write_text(
-            "---\n"
-            'title: "Published Page"\n'
-            "status: publish\n"
-            "---\n"
-            "\n"
-            "Going live.\n"
+            '---\ntitle: "Published Page"\nstatus: publish\n---\n\nGoing live.\n'
         )
         _, _, status, _ = wp_publish.parse_page(str(md))
         assert status == "publish"
@@ -264,8 +243,13 @@ class TestPublishPage:
 
         with patch("requests.post", return_value=mock_response) as mock_post:
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Test Title", "test-slug", "draft", "<p>Hello</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Test Title",
+                "test-slug",
+                "draft",
+                "<p>Hello</p>",
             )
 
         assert result == 0
@@ -288,8 +272,13 @@ class TestPublishPage:
 
         with patch("requests.post", return_value=mock_response) as mock_post:
             wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "",
+                "draft",
+                "<p>Content</p>",
             )
 
         payload = mock_post.call_args.kwargs["json"]
@@ -306,8 +295,13 @@ class TestPublishPage:
 
         with patch("requests.post", return_value=mock_response):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
             )
 
         assert result == 1
@@ -324,8 +318,13 @@ class TestPublishPage:
 
         with patch("requests.post", return_value=mock_response):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
             )
 
         assert result == 1
@@ -337,8 +336,13 @@ class TestPublishPage:
         """publish_page returns 1 on connection failure."""
         with patch("requests.post", side_effect=requests.ConnectionError("DNS failed")):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
             )
 
         assert result == 1
@@ -349,8 +353,13 @@ class TestPublishPage:
         """publish_page returns 1 on request timeout."""
         with patch("requests.post", side_effect=requests.Timeout("timed out")):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
             )
 
         assert result == 1
@@ -359,10 +368,17 @@ class TestPublishPage:
 
     def test_generic_request_error_returns_one(self, capsys):
         """publish_page returns 1 on generic RequestException."""
-        with patch("requests.post", side_effect=requests.RequestException("something broke")):
+        with patch(
+            "requests.post", side_effect=requests.RequestException("something broke")
+        ):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
             )
 
         assert result == 1
@@ -377,8 +393,13 @@ class TestPublishPage:
 
         with patch("requests.post", return_value=mock_response):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
                 admin_path="secret-admin",
             )
 
@@ -394,8 +415,13 @@ class TestPublishPage:
 
         with patch("requests.post", return_value=mock_response):
             result = wp_publish.publish_page(
-                "https://example.com", "user", "pass",
-                "Title", "slug", "draft", "<p>Content</p>",
+                "https://example.com",
+                "user",
+                "pass",
+                "Title",
+                "slug",
+                "draft",
+                "<p>Content</p>",
             )
 
         assert result == 0
@@ -513,7 +539,6 @@ class TestCreateSiteConfig:
 
         env_path = wp_publish.create_site_config(site_name="test")
 
-        import stat
         mode = env_path.stat().st_mode & 0o777
         assert mode == 0o600
 
@@ -595,6 +620,7 @@ class TestCreateSiteConfig:
         monkeypatch.setattr("builtins.input", lambda prompt: next(inputs))
 
         getpass_called = []
+
         def mock_getpass(prompt):
             getpass_called.append(prompt)
             return "secret"
@@ -617,7 +643,9 @@ class TestResolveConfig:
         monkeypatch.delenv("WP_APP_PASSWORD", raising=False)
         monkeypatch.delenv("WP_ADMIN_PATH", raising=False)
 
-        site_url, user, password, admin_path = wp_publish.resolve_config(site_name="demo")
+        site_url, user, password, admin_path = wp_publish.resolve_config(
+            site_name="demo"
+        )
         assert site_url == "https://demo.example.com"
         assert user == "demouser"
         assert password == "demo-pass"
@@ -675,7 +703,9 @@ class TestResolveConfig:
 
     def test_zero_configs_triggers_creation(self, xdg_config, monkeypatch):
         """resolve_config offers creation when no configs exist."""
-        monkeypatch.setattr(wp_publish, "__file__", str(xdg_config / "fake" / "wp-publish.py"))
+        monkeypatch.setattr(
+            wp_publish, "__file__", str(xdg_config / "fake" / "wp-publish.py")
+        )
         (xdg_config / "wpa").mkdir(parents=True)
 
         # Mock the input sequence for create_site_config
@@ -725,6 +755,7 @@ class TestResolveConfig:
 
         input_called = []
         original_input = input
+
         def tracking_input(prompt):
             input_called.append(prompt)
             return original_input(prompt)
@@ -786,9 +817,7 @@ class TestLoadEnv:
         site_dir.mkdir(parents=True)
         env = site_dir / ".env"
         env.write_text(
-            "WP_SITE_URL=http://insecure.com\n"
-            "WP_USER=user\n"
-            "WP_APP_PASSWORD=pass\n"
+            "WP_SITE_URL=http://insecure.com\nWP_USER=user\nWP_APP_PASSWORD=pass\n"
         )
         monkeypatch.delenv("WP_SITE_URL", raising=False)
         monkeypatch.delenv("WP_USER", raising=False)
@@ -824,7 +853,9 @@ class TestMigrateRepoEnv:
         monkeypatch.setattr(wp_publish, "__file__", str(tmp_path / "wp-publish.py"))
         assert wp_publish.migrate_repo_env() is None
 
-    def test_existing_xdg_configs_skips_migration(self, single_site, tmp_path, monkeypatch):
+    def test_existing_xdg_configs_skips_migration(
+        self, single_site, tmp_path, monkeypatch
+    ):
         """migrate_repo_env returns None when XDG configs already exist."""
         repo_env = tmp_path / ".env"
         repo_env.write_text("WP_SITE_URL=https://old.com\n")
@@ -862,9 +893,7 @@ class TestMigrateRepoEnv:
         """migrate_repo_env deletes repo .env when user confirms."""
         repo_env = tmp_path / ".env"
         repo_env.write_text(
-            "WP_SITE_URL=https://old.com\n"
-            "WP_USER=user\n"
-            "WP_APP_PASSWORD=pass\n"
+            "WP_SITE_URL=https://old.com\nWP_USER=user\nWP_APP_PASSWORD=pass\n"
         )
         monkeypatch.setattr(wp_publish, "__file__", str(tmp_path / "wp-publish.py"))
         inputs = iter(["oldsite", "y"])
@@ -877,9 +906,7 @@ class TestMigrateRepoEnv:
         """migrate_repo_env keeps repo .env when user declines deletion."""
         repo_env = tmp_path / ".env"
         repo_env.write_text(
-            "WP_SITE_URL=https://old.com\n"
-            "WP_USER=user\n"
-            "WP_APP_PASSWORD=pass\n"
+            "WP_SITE_URL=https://old.com\nWP_USER=user\nWP_APP_PASSWORD=pass\n"
         )
         monkeypatch.setattr(wp_publish, "__file__", str(tmp_path / "wp-publish.py"))
         inputs = iter(["oldsite", "n"])
@@ -888,7 +915,9 @@ class TestMigrateRepoEnv:
         wp_publish.migrate_repo_env()
         assert repo_env.exists()
 
-    def test_migration_invalid_name_returns_none(self, xdg_config, tmp_path, monkeypatch):
+    def test_migration_invalid_name_returns_none(
+        self, xdg_config, tmp_path, monkeypatch
+    ):
         """migrate_repo_env returns None on invalid site name."""
         repo_env = tmp_path / ".env"
         repo_env.write_text("WP_SITE_URL=https://old.com\n")
@@ -917,7 +946,9 @@ class TestMain:
         monkeypatch.delenv("WP_USER", raising=False)
         monkeypatch.delenv("WP_APP_PASSWORD", raising=False)
         monkeypatch.delenv("WP_ADMIN_PATH", raising=False)
-        monkeypatch.setattr("sys.argv", ["wp-publish.py", "--site", "demo", str(valid_md_file)])
+        monkeypatch.setattr(
+            "sys.argv", ["wp-publish.py", "--site", "demo", str(valid_md_file)]
+        )
 
         mock_response = MagicMock()
         mock_response.status_code = 201
@@ -947,4 +978,32 @@ class TestMain:
             wp_publish.main()
         assert exc_info.value.code == 0
         output = capsys.readouterr().out
-        assert "0.2.0" in output
+        assert "0.2.1" in output
+
+    def test_help_includes_examples(self, monkeypatch, capsys):
+        """--help output includes usage examples."""
+        monkeypatch.setattr("sys.argv", ["wp-publish.py", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            wp_publish.main()
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "examples:" in output
+        assert "--site demo" in output
+
+    def test_help_includes_config_location(self, monkeypatch, capsys):
+        """--help output shows config file location."""
+        monkeypatch.setattr("sys.argv", ["wp-publish.py", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            wp_publish.main()
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "~/.config/wpa/" in output
+
+    def test_help_includes_first_run_note(self, monkeypatch, capsys):
+        """--help output mentions first-run config creation."""
+        monkeypatch.setattr("sys.argv", ["wp-publish.py", "--help"])
+        with pytest.raises(SystemExit) as exc_info:
+            wp_publish.main()
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "first run" in output.lower() or "prompted to create" in output.lower()

--- a/wp-publish.py
+++ b/wp-publish.py
@@ -13,7 +13,7 @@ import markdown
 import requests
 from dotenv import load_dotenv
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 VALID_STATUSES = {"draft", "publish", "pending", "private"}
 SITE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
@@ -33,9 +33,7 @@ def list_sites():
     if not config_dir.exists():
         return []
     return sorted(
-        d.name
-        for d in config_dir.iterdir()
-        if d.is_dir() and (d / ".env").exists()
+        d.name for d in config_dir.iterdir() if d.is_dir() and (d / ".env").exists()
     )
 
 
@@ -55,14 +53,20 @@ def create_site_config(site_name=None):
         site_name = input("Site name: ").strip()
 
     if not validate_site_name(site_name):
-        print(f"Error: Invalid site name '{site_name}'. Use alphanumeric characters and hyphens only.")
+        print(
+            f"Error: Invalid site name '{site_name}'. Use alphanumeric characters and hyphens only."
+        )
         sys.exit(1)
 
     config_dir = get_config_dir()
     site_dir = config_dir / site_name
 
     if site_dir.exists() and (site_dir / ".env").exists():
-        confirm = input(f"Config '{site_name}' already exists. Overwrite? [y/N]: ").strip().lower()
+        confirm = (
+            input(f"Config '{site_name}' already exists. Overwrite? [y/N]: ")
+            .strip()
+            .lower()
+        )
         if confirm != "y":
             print("Cancelled.")
             sys.exit(0)
@@ -116,12 +120,16 @@ def migrate_repo_env():
         return None  # Already have XDG configs, don't offer migration
 
     print(f"Found repo-root config at {repo_env}")
-    site_name = input("Migrate to XDG config? Enter site name (or press Enter to skip): ").strip()
+    site_name = input(
+        "Migrate to XDG config? Enter site name (or press Enter to skip): "
+    ).strip()
     if not site_name:
         return None
 
     if not validate_site_name(site_name):
-        print(f"Error: Invalid site name '{site_name}'. Use alphanumeric characters and hyphens only.")
+        print(
+            f"Error: Invalid site name '{site_name}'. Use alphanumeric characters and hyphens only."
+        )
         return None
 
     config_dir = get_config_dir()
@@ -215,7 +223,9 @@ def _load_env(env_path):
     admin_path = os.environ.get("WP_ADMIN_PATH", "wp-admin")
 
     if not all([site_url, user, password]):
-        print(f"Error: WP_SITE_URL, WP_USER, and WP_APP_PASSWORD must all be set in {env_path}")
+        print(
+            f"Error: WP_SITE_URL, WP_USER, and WP_APP_PASSWORD must all be set in {env_path}"
+        )
         sys.exit(1)
 
     if not site_url.startswith("https://"):
@@ -232,7 +242,9 @@ def load_config(env_path):
     New code should use resolve_config() which returns 4-tuple with admin_path.
     """
     if not Path(env_path).exists():
-        print(f"Error: {env_path} not found. Copy .env.example to .env and fill in credentials.")
+        print(
+            f"Error: {env_path} not found. Copy .env.example to .env and fill in credentials."
+        )
         sys.exit(1)
 
     load_dotenv(env_path, override=True)
@@ -242,7 +254,9 @@ def load_config(env_path):
     password = os.environ.get("WP_APP_PASSWORD", "")
 
     if not all([site_url, user, password]):
-        print("Error: WP_SITE_URL, WP_USER, and WP_APP_PASSWORD must all be set in .env")
+        print(
+            "Error: WP_SITE_URL, WP_USER, and WP_APP_PASSWORD must all be set in .env"
+        )
         sys.exit(1)
 
     if not site_url.startswith("https://"):
@@ -270,7 +284,9 @@ def parse_page(filepath):
     status = post.get("status", "draft")
 
     if status not in VALID_STATUSES:
-        print(f"Error: Invalid status '{status}' in {filepath}. Must be one of: {', '.join(sorted(VALID_STATUSES))}")
+        print(
+            f"Error: Invalid status '{status}' in {filepath}. Must be one of: {', '.join(sorted(VALID_STATUSES))}"
+        )
         sys.exit(1)
 
     html_content = markdown.markdown(post.content)
@@ -278,7 +294,9 @@ def parse_page(filepath):
     return title, slug, status, html_content
 
 
-def publish_page(site_url, user, password, title, slug, status, content, admin_path="wp-admin"):
+def publish_page(
+    site_url, user, password, title, slug, status, content, admin_path="wp-admin"
+):
     """POST a page to WordPress REST API."""
     endpoint = f"{site_url}/wp-json/wp/v2/pages"
 
@@ -298,7 +316,9 @@ def publish_page(site_url, user, password, title, slug, status, content, admin_p
             timeout=30,
         )
     except requests.ConnectionError:
-        print(f"Error: Could not connect to {site_url}. Check the URL and your network connection.")
+        print(
+            f"Error: Could not connect to {site_url}. Check the URL and your network connection."
+        )
         return 1
     except requests.Timeout:
         print(f"Error: Request to {site_url} timed out after 30 seconds.")
@@ -311,7 +331,7 @@ def publish_page(site_url, user, password, title, slug, status, content, admin_p
         data = response.json()
         page_id = data["id"]
         edit_url = f"{site_url}/{admin_path}/post.php?post={page_id}&action=edit"
-        print(f"Page created successfully!")
+        print("Page created successfully!")
         print(f"  ID:       {page_id}")
         print(f"  Title:    {title}")
         print(f"  Status:   {status}")
@@ -331,11 +351,32 @@ def publish_page(site_url, user, password, title, slug, status, content, admin_p
 def main():
     parser = argparse.ArgumentParser(
         description="Publish markdown files as WordPress pages.",
+        epilog="""\
+examples:
+  %(prog)s pages/my-page.md              Publish using auto-detected site config
+  %(prog)s --site demo pages/my-page.md  Publish using the "demo" site config
+  %(prog)s --new-site                    Create a new site config interactively
+
+config:
+  Site configs are stored at ~/.config/wpa/<site-name>/.env
+  On first run with no configs, you will be prompted to create one.
+""",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("file", nargs="?", help="Path to markdown file with YAML frontmatter")
-    parser.add_argument("--site", help="Use named site config from ~/.config/wpa/<name>/")
-    parser.add_argument("--new-site", action="store_true", help="Create a new site config interactively")
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    parser.add_argument(
+        "file", nargs="?", help="Path to markdown file with YAML frontmatter"
+    )
+    parser.add_argument(
+        "--site", help="Use named site config from ~/.config/wpa/<name>/"
+    )
+    parser.add_argument(
+        "--new-site",
+        action="store_true",
+        help="Create a new site config interactively",
+    )
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
     args = parser.parse_args()
 
     if args.new_site:
@@ -349,7 +390,9 @@ def main():
     title, slug, status, content = parse_page(args.file)
 
     print(f"Publishing '{title}' as {status} to {site_url}...")
-    return publish_page(site_url, user, password, title, slug, status, content, admin_path=admin_path)
+    return publish_page(
+        site_url, user, password, title, slug, status, content, admin_path=admin_path
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **GitHub Actions CI** — Automated pytest + ruff lint + ruff format on push and PR to main
- **Improved CLI help** — `--help` now shows usage examples, config location, and first-run guidance
- **Code quality** — Fixed 4 ruff lint issues, auto-formatted codebase

## Quality

- 72 tests | 99% coverage
- ruff check + ruff format clean

## Test plan

- [ ] CI pipeline passes on GitHub (pytest, ruff check, ruff format)
- [ ] `python3 wp-publish.py --help` shows examples, config location, first-run note
- [ ] `python3 wp-publish.py --version` shows 0.2.1
- [ ] All 72 tests pass locally

Closes #2, Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)