### PR TITLE
v0.8.2: comment count + markdown --file input for post/page create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ CI runs on ubuntu/macos/windows across Python 3.9, 3.11, 3.12, 3.13. The require
 
 ## Architecture
 
-**Entry point**: `wpa/cli.py` — argparse-based CLI with subcommands (`publish`, `post list/get/create/update/delete`, `page list/get/create/update/delete`, `site add/list`, `user list/get/create/update/delete/set-role`, `media list/get/import/delete`, `comment list/get/create/update/delete/approve/unapprove/spam/unspam/trash`, `term list/get/create/update/delete`, plus `category` and `tag` aliases).
+**Entry point**: `wpa/cli.py` — argparse-based CLI with subcommands (`publish`, `post list/get/create/update/delete`, `page list/get/create/update/delete`, `site add/list`, `user list/get/create/update/delete/set-role`, `media list/get/import/delete`, `comment list/get/create/update/delete/approve/unapprove/spam/unspam/trash/count`, `term list/get/create/update/delete`, plus `category` and `tag` aliases).
 
 **Modules**:
 - `cli.py` — Command parsing, dispatches to other modules
@@ -44,13 +44,13 @@ CI runs on ubuntu/macos/windows across Python 3.9, 3.11, 3.12, 3.13. The require
 - `publish.py` — Parses YAML frontmatter from markdown files, converts to HTML, creates pages via `WPApiClient`. Default status is `draft`
 - `user.py` — User CRUD operations against `/wp-json/wp/v2/users`. Uses `WPApiClient` for all requests. Supports `list`, `get`, `create`, `update`, `delete`, and `set-role` (shortcut for changing a user's role)
 - `media.py` — Media CRUD operations against `/wp-json/wp/v2/media`. Uses `WPApiClient` for all requests. Supports `list` (with `--media-type`/`--mime-type` filters), `get`, `import` (multipart upload from a local file with optional title/alt-text/caption/description/post), and `delete` (trash-aware, `--force` to permanently delete)
-- `comment.py` — Comment CRUD and moderation against `/wp-json/wp/v2/comments`. Supports `list` (filter by post, status, parent, author email, search), `get`, `create`, `update`, `delete` (trash-aware, `--force` to permanently delete), plus moderation shortcuts `approve`, `unapprove`, `spam`, `unspam`, `trash`
+- `comment.py` — Comment CRUD and moderation against `/wp-json/wp/v2/comments`. Supports `list` (filter by post, status, parent, author email, search), `get`, `create`, `update`, `delete` (trash-aware, `--force` to permanently delete), plus moderation shortcuts `approve`, `unapprove`, `spam`, `unspam`, `trash`, and `count` (per-status totals via the `X-WP-Total` header)
 - `term.py` — Taxonomy term CRUD against `/wp-json/wp/v2/{categories,tags,<custom>}`. One module handles built-in taxonomies (`category` → `categories`, `post_tag` → `tags`) and custom taxonomies (passed through by slug). The CLI exposes `wpa term --taxonomy <slug>` plus thin `wpa category` / `wpa tag` aliases that pre-set the taxonomy. Term `delete` is always permanent (the REST API does not support trashing terms).
 - `formatter.py` — Shared output formatting (table, json, csv, tsv) with column selection via `--fields`, plus `--ids`, `--count`, `--field` output modifiers
 
 **Global flags**: `--debug` (HTTP request/response details) available on all commands. `--site` selects a named site config.
 
-**Tests**: All in `tests/` (488 tests), use `unittest.mock` to mock HTTP requests. No live WordPress connection needed.
+**Tests**: All in `tests/` (503 tests), use `unittest.mock` to mock HTTP requests. No live WordPress connection needed.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ wpa post get 42 --site mysite
 # Create a post
 wpa post create --site mysite --title "My Post" --content "<p>Hello</p>" --status draft
 
+# Create a post from a markdown file (YAML frontmatter supplies
+# title/status/slug; CLI flags override frontmatter)
+wpa post create --site mysite --file article.md --author 15 --categories 3,7
+
 # Update a post
 wpa post update 42 --site mysite --title "Updated Title" --status publish
 
@@ -72,8 +76,10 @@ wpa page list --site mysite --status publish --parent 10
 # Get a single page
 wpa page get 42 --site mysite
 
-# Create a page from markdown file
+# Create a page from a markdown file (positional or --file; CLI flags
+# like --parent/--author/--status override frontmatter)
 wpa page create --site mysite pages/about.md
+wpa page create --site mysite --file pages/about.md --parent 12
 
 # Create a page from flags
 wpa page create --site mysite --title "About" --content "<p>About us</p>"
@@ -162,6 +168,11 @@ wpa comment list --site mysite
 wpa comment list --site mysite --status hold
 wpa comment list --site mysite --post 42 --status approved
 wpa comment list --site mysite --author-email "reviewer@example.com"
+
+# Count comments per moderation status (one lightweight request each)
+wpa comment count --site mysite
+wpa comment count --site mysite --status hold      # bare number
+wpa comment count --site mysite --format json
 
 # Get a single comment
 wpa comment get 123 --site mysite

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,52 @@
 # Release Notes
 
+## v0.8.2 — Quick Wins: Comment Counts + Markdown Input (2026-08-08)
+
+Two quality-of-life features rolled up from the issue backlog.
+
+### `wpa comment count` (#34)
+
+Moderation-queue monitoring in one command instead of four:
+
+```bash
+wpa comment count                      # approved/hold/spam/trash summary
+wpa comment count --status hold        # bare number for scripting
+wpa comment count --format json        # {"approved": 1423, "hold": 7, ...}
+```
+
+Implementation: one lightweight request per status, reading the `X-WP-Total`
+header from a `per_page=1` fetch via the new `WPApiClient.get_total()` —
+counting never paginates through comment bodies. The `approved`→`approve`
+REST-API status asymmetry from v0.8.0 is normalized here too.
+
+### `--file` markdown input for `post create` and `page create` (#27)
+
+Both commands now accept a markdown file with YAML frontmatter, reusing the
+same conversion pipeline as `wpa publish`:
+
+```bash
+wpa post create --file article.md --author 15 --categories 3,7
+wpa page create --file about.md --parent 12 --status draft
+```
+
+- Frontmatter supplies `title`, `status`, `slug`; the body converts to HTML.
+- Explicit CLI flags override frontmatter (`--status draft` beats
+  `status: publish` in the file).
+- `--file` and `--content` are mutually exclusive; `--title` is only
+  required when no file supplies one.
+
+**Behavior change:** `wpa page create <file.md>` (the positional form) now
+routes through the same path as `--file`, so metadata flags (`--author`,
+`--parent`, `--menu-order`, `--status`, `--slug`) finally apply when creating
+from a file. Previously the positional form silently ignored them by
+delegating to the legacy publish path. `wpa publish` itself is unchanged.
+
+### Quality
+
+- **Tests:** 503 total, +15 from v0.8.1 (`get_total`, `count_comments`,
+  `resolve_file_fields`).
+- `ruff check` / `ruff format --check` clean.
+
 ## v0.8.1 — User Notifications + WAF Detection (2026-08-08)
 
 Bug-fix and hardening release addressing the v0.8.0 security-audit follow-ups

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpa"
-version = "0.8.1"
+version = "0.8.2"
 description = "WordPress Automation — manage posts, pages, and users via the REST API"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -828,3 +828,66 @@ class TestRequestPasswordReset:
         mock_post.return_value = resp
         with pytest.raises(WPApiError, match="tls_downgrade|http"):
             client.request_password_reset("newuser")
+
+
+class TestGetTotal:
+    """get_total() — X-WP-Total via a single-item fetch."""
+
+    def _response(self, total="1423", items=None):
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.headers = {"X-WP-Total": total} if total is not None else {}
+        resp.content = b"[{}]"
+        resp.json.return_value = items if items is not None else [{}]
+        resp.url = "https://example.com/wp-json/wp/v2/comments"
+        return resp
+
+    @patch("wpa.api.requests.get")
+    def test_returns_header_total(self, mock_get, client):
+        mock_get.return_value = self._response("1423")
+        assert client.get_total("comments") == 1423
+
+    @patch("wpa.api.requests.get")
+    def test_fetches_single_item(self, mock_get, client):
+        mock_get.return_value = self._response()
+        client.get_total("comments", params={"status": "hold"})
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["per_page"] == 1
+        assert kwargs["params"]["status"] == "hold"
+
+    @patch("wpa.api.requests.get")
+    def test_does_not_mutate_caller_params(self, mock_get, client):
+        mock_get.return_value = self._response()
+        params = {"status": "hold"}
+        client.get_total("comments", params=params)
+        assert params == {"status": "hold"}
+
+    @patch("wpa.api.requests.get")
+    def test_missing_header_falls_back_to_body_length(self, mock_get, client):
+        mock_get.return_value = self._response(total=None, items=[{}, {}])
+        assert client.get_total("comments") == 2
+
+    @patch("wpa.api.requests.get")
+    def test_malformed_header_falls_back(self, mock_get, client):
+        mock_get.return_value = self._response(total="lots")
+        assert client.get_total("comments") == 1
+
+    @patch("wpa.api.requests.get")
+    def test_error_response_raises(self, mock_get, client):
+        resp = MagicMock()
+        resp.ok = False
+        resp.status_code = 403
+        resp.headers = {}
+        resp.content = b'{"code": "rest_forbidden"}'
+        resp.json.return_value = {"code": "rest_forbidden", "message": "No."}
+        resp.url = "https://example.com/wp-json/wp/v2/comments"
+        mock_get.return_value = resp
+        with pytest.raises(WPApiError):
+            client.get_total("comments")
+
+    @patch("wpa.api.requests.get")
+    def test_connection_error(self, mock_get, client):
+        mock_get.side_effect = requests.ConnectionError("refused")
+        with pytest.raises(WPConnectionError):
+            client.get_total("comments")

--- a/tests/test_comment.py
+++ b/tests/test_comment.py
@@ -9,6 +9,7 @@ from wpa.comment import (
     DEFAULT_FIELDS,
     _extract_comment_row,
     approve_comment,
+    count_comments,
     create_comment,
     delete_comment,
     get_comment,
@@ -337,3 +338,40 @@ class TestModerationActions:
     def test_spam_invalid_id(self, mock_client):
         with pytest.raises(ValueError, match="Invalid comment ID"):
             spam_comment(mock_client, -1)
+
+
+# --- count_comments ---
+
+
+class TestCountComments:
+    def test_counts_all_statuses(self, mock_client):
+        mock_client.get_total.side_effect = [1423, 7, 89, 12]
+        counts = count_comments(mock_client)
+        assert counts == {"approved": 1423, "hold": 7, "spam": 89, "trash": 12}
+        assert mock_client.get_total.call_count == 4
+
+    def test_normalizes_approved_to_approve(self, mock_client):
+        # Same REST API asymmetry as list_comments — query param is 'approve'
+        mock_client.get_total.return_value = 5
+        count_comments(mock_client, status="approved")
+        params = mock_client.get_total.call_args[1]["params"]
+        assert params["status"] == "approve"
+        assert params["context"] == "edit"
+
+    def test_single_status(self, mock_client):
+        mock_client.get_total.return_value = 7
+        counts = count_comments(mock_client, status="hold")
+        assert counts == {"hold": 7}
+        mock_client.get_total.assert_called_once()
+        params = mock_client.get_total.call_args[1]["params"]
+        assert params["status"] == "hold"
+
+    def test_unknown_status_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Unknown status 'bogus'"):
+            count_comments(mock_client, status="bogus")
+        mock_client.get_total.assert_not_called()
+
+    def test_preserves_display_order(self, mock_client):
+        mock_client.get_total.side_effect = [1, 2, 3, 4]
+        counts = count_comments(mock_client)
+        assert list(counts) == ["approved", "hold", "spam", "trash"]

--- a/tests/test_wp_publish.py
+++ b/tests/test_wp_publish.py
@@ -19,7 +19,12 @@ from wpa.config import (
     validate_site_name,
 )
 from wpa.exceptions import WPApiError, WPConnectionError, WPTimeoutError
-from wpa.publish import parse_markdown, parse_page, publish_page
+from wpa.publish import (
+    parse_markdown,
+    parse_page,
+    publish_page,
+    resolve_file_fields,
+)
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1096,3 +1101,42 @@ class TestParseMarkdown:
         assert slug == data["slug"]
         assert status == data["status"]
         assert content == data["content"]
+
+
+# --- resolve_file_fields (post/page create --file) ---
+
+
+class TestResolveFileFields:
+    @staticmethod
+    def _file_data():
+        return {
+            "title": "From File",
+            "slug": "from-file",
+            "status": "publish",
+            "content": "<p>Body</p>",
+        }
+
+    def test_frontmatter_only(self):
+        title, content, status, slug = resolve_file_fields(self._file_data())
+        assert title == "From File"
+        assert content == "<p>Body</p>"
+        assert status == "publish"
+        assert slug == "from-file"
+
+    def test_cli_flags_override_frontmatter(self):
+        title, content, status, slug = resolve_file_fields(
+            self._file_data(), title="CLI Title", status="draft", slug="cli-slug"
+        )
+        assert title == "CLI Title"
+        assert status == "draft"
+        assert slug == "cli-slug"
+        # content always comes from the file
+        assert content == "<p>Body</p>"
+
+    def test_defaults_when_frontmatter_sparse(self):
+        title, _content, status, slug = resolve_file_fields(
+            {"title": "Minimal", "slug": "", "status": "", "content": "<p>x</p>"}
+        )
+        assert title == "Minimal"
+        assert status == "draft"
+        assert slug is None

--- a/wpa-prd.md
+++ b/wpa-prd.md
@@ -4,7 +4,7 @@
 **Version:** PRD v1.2
 **Date:** 2026-04-14
 **Author:** Neil Johnson, Cadent Creative
-**Current release:** v0.8.1
+**Current release:** v0.8.2
 **Repository:** [github.com/cadentdev/wpa](https://github.com/cadentdev/wpa)
 **PyPI:** [pypi.org/project/wpa](https://pypi.org/project/wpa/)
 **License:** MIT

--- a/wpa/__init__.py
+++ b/wpa/__init__.py
@@ -1,3 +1,3 @@
 """WordPress Automation — manage posts, pages, and users via the REST API."""
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"

--- a/wpa/api.py
+++ b/wpa/api.py
@@ -356,6 +356,55 @@ class WPApiClient:
         """
         return self._request("GET", self._url(endpoint), params=params)
 
+    def get_total(self, endpoint, params=None):
+        """Return the total number of items in a collection.
+
+        Fetches a single item (per_page=1) and reads the X-WP-Total header,
+        so counting a large collection costs one lightweight request instead
+        of paginating through everything.
+
+        Args:
+            endpoint: API path (e.g., 'comments').
+            params: Optional query parameters (filters).
+
+        Returns:
+            Total item count as an int.
+        """
+        params = {**(params or {}), "per_page": 1}
+        url = self._url(endpoint)
+
+        self._debug_log("GET", url, params=params)
+
+        try:
+            response = requests.get(
+                url, headers=self._headers(), params=params, timeout=self.timeout
+            )
+        except requests.ConnectionError:
+            raise WPConnectionError(
+                f"Could not connect to {self.site_url}. "
+                "Check the URL and your network connection."
+            )
+        except requests.Timeout:
+            raise WPTimeoutError(
+                f"Request to {self.site_url} timed out after {self.timeout} seconds."
+            )
+        except requests.RequestException as e:
+            raise WPConnectionError(f"Request failed: {e}")
+
+        self._debug_log("GET", url, response=response)
+
+        self._check_no_scheme_downgrade(response)
+        self._check_response_size(response)
+
+        # Raises on error responses; the body itself is discarded.
+        data = self._handle_response(response)
+
+        try:
+            return int(response.headers.get("X-WP-Total"))
+        except (TypeError, ValueError):
+            # Header missing or malformed — fall back to what we can see.
+            return len(data) if isinstance(data, list) else 0
+
     def get_list(self, endpoint, params=None):
         """GET a paginated list of resources.
 

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -7,7 +7,11 @@ import sys
 from wpa import __version__
 from wpa.api import WPApiClient
 from wpa.comment import (
+    COUNT_STATUSES as COMMENT_COUNT_STATUSES,
+)
+from wpa.comment import (
     approve_comment,
+    count_comments,
     create_comment,
     delete_comment,
     get_comment,
@@ -53,7 +57,7 @@ from wpa.post import (
 from wpa.post import (
     validate_fields as validate_post_fields,
 )
-from wpa.publish import parse_page, publish_page
+from wpa.publish import parse_markdown, parse_page, publish_page, resolve_file_fields
 from wpa.term import (
     create_term,
     delete_term,
@@ -236,6 +240,13 @@ def _do_post_get(args):  # pragma: no cover
 def _do_post_create(args):  # pragma: no cover
     """Create a new WordPress post."""
     try:
+        if args.file and args.content:
+            print("Error: --file and --content are mutually exclusive.")
+            return 1
+        if not args.file and not args.title:
+            print("Error: Provide --title, or --file with a markdown file.")
+            return 1
+
         client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
 
         # Parse categories and tags from comma-separated strings
@@ -247,12 +258,25 @@ def _do_post_create(args):  # pragma: no cover
         if args.tags:
             tags = [int(t.strip()) for t in args.tags.split(",")]
 
+        if args.file:
+            # Markdown file: frontmatter supplies title/status/slug and the
+            # body converts to HTML; explicit CLI flags win over frontmatter.
+            data = parse_markdown(args.file)
+            title, content, status, slug = resolve_file_fields(
+                data, title=args.title, status=args.status, slug=args.slug
+            )
+        else:
+            title = args.title
+            content = args.content or ""
+            status = args.status or "draft"
+            slug = args.slug
+
         result = create_post(
             client,
-            title=args.title,
-            content=args.content or "",
-            status=args.status,
-            slug=args.slug,
+            title=title,
+            content=content,
+            status=status,
+            slug=slug,
             author=args.author,
             categories=categories,
             tags=tags,
@@ -360,25 +384,44 @@ def _do_page_get(args):  # pragma: no cover
 
 
 def _do_page_create_dispatch(args):  # pragma: no cover
-    """Dispatch page create — markdown file or CLI flags."""
-    if args.file:
-        return _do_publish(args)
-    if not args.title:
+    """Dispatch page create — markdown file (positional or --file) or flags."""
+    if args.file and args.file_opt:
+        print("Error: pass the markdown file once (positional or --file).")
+        return 1
+    file_path = args.file or args.file_opt
+    if file_path and args.content:
+        print("Error: --file and --content are mutually exclusive.")
+        return 1
+    if not file_path and not args.title:
         print("Error: Provide a markdown file or --title to create a page.")
         return 1
-    return _do_page_create(args)
+    return _do_page_create(args, file_path=file_path)
 
 
-def _do_page_create(args):  # pragma: no cover
-    """Create a new WordPress page from CLI flags."""
+def _do_page_create(args, file_path=None):  # pragma: no cover
+    """Create a new WordPress page from a markdown file and/or CLI flags."""
     try:
         client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+
+        if file_path:
+            # Frontmatter supplies title/status/slug and the body converts
+            # to HTML; explicit CLI flags win over frontmatter.
+            data = parse_markdown(file_path)
+            title, content, status, slug = resolve_file_fields(
+                data, title=args.title, status=args.status, slug=args.slug
+            )
+        else:
+            title = args.title
+            content = args.content or ""
+            status = args.status or "draft"
+            slug = args.slug
+
         result = create_page(
             client,
-            title=args.title,
-            content=args.content or "",
-            status=args.status,
-            slug=args.slug,
+            title=title,
+            content=content,
+            status=status,
+            slug=slug,
             parent=args.parent,
             author=args.author,
             menu_order=args.menu_order,
@@ -867,6 +910,31 @@ def _do_comment_trash(args):  # pragma: no cover
         return _handle_api_error(e)
 
 
+def _do_comment_count(args):  # pragma: no cover
+    """Count comments per moderation status."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        counts = count_comments(client, status=args.status)
+
+        if args.status:
+            print(counts[args.status])
+            return 0
+
+        if args.format == "json":
+            print(json.dumps(counts))
+            return 0
+
+        width = max(len(s) for s in counts) + 1
+        for s, n in counts.items():
+            print(f"{s + ':':<{width}} {n}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
 # --- Term handlers ---
 
 
@@ -1084,11 +1152,21 @@ def main(argv=None):
     post_create_parser = post_subparsers.add_parser(
         "create", parents=[shared], help="Create a new post"
     )
-    post_create_parser.add_argument("--title", required=True, help="Post title")
+    post_create_parser.add_argument(
+        "--title", help="Post title (required unless --file supplies one)"
+    )
     post_create_parser.add_argument("--content", help="Post content (HTML)")
     post_create_parser.add_argument(
+        "--file",
+        help=(
+            "Markdown file with YAML frontmatter; the body is converted to "
+            "HTML. CLI flags override frontmatter. Mutually exclusive with "
+            "--content."
+        ),
+    )
+    post_create_parser.add_argument(
         "--status",
-        default="draft",
+        default=None,
         help="Post status (default: draft)",
     )
     post_create_parser.add_argument("--slug", help="URL slug")
@@ -1168,10 +1246,19 @@ def main(argv=None):
         default=None,
         help="Path to markdown file with YAML frontmatter",
     )
+    page_create_parser.add_argument(
+        "--file",
+        dest="file_opt",
+        help=(
+            "Markdown file with YAML frontmatter (same as the positional "
+            "argument). CLI flags override frontmatter. Mutually exclusive "
+            "with --content."
+        ),
+    )
     page_create_parser.add_argument("--title", help="Page title")
     page_create_parser.add_argument("--content", help="Page content (HTML)")
     page_create_parser.add_argument(
-        "--status", default="draft", help="Page status (default: draft)"
+        "--status", default=None, help="Page status (default: draft)"
     )
     page_create_parser.add_argument("--slug", help="URL slug")
     page_create_parser.add_argument("--parent", type=int, help="Parent page ID")
@@ -1467,6 +1554,23 @@ def main(argv=None):
         "--force", action="store_true", help="Permanently delete (skip trash)"
     )
     comment_delete_parser.set_defaults(func=_do_comment_delete)
+
+    # wpa comment count
+    comment_count_parser = comment_subparsers.add_parser(
+        "count", parents=[shared], help="Count comments per moderation status"
+    )
+    comment_count_parser.add_argument(
+        "--status",
+        choices=list(COMMENT_COUNT_STATUSES),
+        help="Count a single status (bare number output)",
+    )
+    comment_count_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    comment_count_parser.set_defaults(func=_do_comment_count)
 
     # Comment moderation subcommands
     for action_name, action_func, help_text in (

--- a/wpa/comment.py
+++ b/wpa/comment.py
@@ -146,6 +146,43 @@ def list_comments(
     return [_extract_comment_row(c) for c in client.get_list("comments", params=params)]
 
 
+# Statuses reported by `wpa comment count`, in display order.
+COUNT_STATUSES = ("approved", "hold", "spam", "trash")
+
+
+def count_comments(client, status=None):
+    """Count comments per moderation status.
+
+    One lightweight request per status (X-WP-Total header via per_page=1),
+    so checking the moderation queue never paginates through comment bodies.
+
+    Args:
+        client: WPApiClient instance.
+        status: Single status to count, or None for all of COUNT_STATUSES.
+
+    Returns:
+        Ordered dict of {status: count}.
+
+    Raises:
+        ValueError: If status is not a known comment status.
+    """
+    if status is not None and status not in COUNT_STATUSES:
+        raise ValueError(
+            f"Unknown status '{status}'. "
+            f"Available statuses: {', '.join(COUNT_STATUSES)}"
+        )
+
+    statuses = (status,) if status else COUNT_STATUSES
+    counts = {}
+    for s in statuses:
+        # Same REST API asymmetry as list_comments: query with 'approve'.
+        query_status = "approve" if s == "approved" else s
+        counts[s] = client.get_total(
+            "comments", params={"context": "edit", "status": query_status}
+        )
+    return counts
+
+
 def get_comment(client, comment_id):
     """Get a single comment by ID.
 

--- a/wpa/publish.py
+++ b/wpa/publish.py
@@ -74,6 +74,31 @@ def parse_page(filepath):
     return data["title"], data["slug"], data["status"], data["content"]
 
 
+def resolve_file_fields(file_data, title=None, status=None, slug=None):
+    """Merge markdown-file fields with CLI flag overrides.
+
+    Used by `post create --file` / `page create --file`: the file's YAML
+    frontmatter supplies title/status/slug and the converted HTML body,
+    and any CLI flag that was explicitly passed wins over frontmatter.
+
+    Args:
+        file_data: Dict from parse_markdown() (title, slug, status, content).
+        title: CLI --title override, or None.
+        status: CLI --status override, or None.
+        slug: CLI --slug override, or None.
+
+    Returns:
+        Tuple of (title, content, status, slug) with overrides applied.
+        status falls back to 'draft', slug to None when empty.
+    """
+    return (
+        title or file_data.get("title"),
+        file_data.get("content", ""),
+        status or file_data.get("status") or "draft",
+        slug or file_data.get("slug") or None,
+    )
+
+
 def publish_page(client, title, slug, status, content, admin_path="wp-admin"):
     """POST a page to WordPress REST API using WPApiClient.
 


### PR DESCRIPTION
## Summary

Quick-wins rollup, **stacked on #46** (v0.8.1) — the base branch is `fix/v0.8.1-user-create-waf-hardening` so this PR shows only the v0.8.2 diff. GitHub will retarget it to `main` automatically when #46 merges.

### `wpa comment count` (closes #34)

Moderation-queue monitoring in one command instead of four list invocations:

- `wpa comment count` — approved/hold/spam/trash summary
- `wpa comment count --status hold` — bare number for scripting
- `wpa comment count --format json` — agent-friendly

One lightweight request per status via the new `WPApiClient.get_total()` (reads `X-WP-Total` from a `per_page=1` fetch — never paginates through comment bodies). Normalizes the `approved`→`approve` REST status asymmetry, same as `comment list`.

### `--file` for `post create` / `page create` (closes #27)

Markdown file with YAML frontmatter, reusing the `wpa publish` conversion pipeline. Frontmatter supplies `title`/`status`/`slug`; explicit CLI flags override; `--file` and `--content` are mutually exclusive; `--title` only required when no file supplies one.

**Behavior change:** `wpa page create <file.md>` (positional) now routes through the same path as `--file`, so `--author`/`--parent`/`--menu-order`/`--status`/`--slug` finally apply when creating from a file — previously the positional form silently ignored them by delegating to the legacy publish path. `wpa publish` is unchanged.

## Test plan

- [x] 503 tests pass (+15: `get_total`, `count_comments`, `resolve_file_fields`)
- [x] `ruff check` / `ruff format --check` clean
- [x] CLI surface smoke-tested (`--help` for the new flags/subcommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia