### PR TITLE
chore(ci): PyPI trusted-publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,41 @@
+name: Publish to PyPI
+
+# Publishes via PyPI Trusted Publishing (OIDC) — no API tokens stored anywhere.
+# Runs automatically when a GitHub Release is published; workflow_dispatch
+# covers releases that predate this workflow or need a re-run.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build and publish (e.g. v0.8.1)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # required for PyPI OIDC trusted publishing
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish.yml`: builds sdist+wheel and publishes to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API tokens stored on disk or in repo secrets.

- Triggers automatically on **GitHub Release published**
- `workflow_dispatch` with a `tag` input covers the already-published v0.8.1 and v0.8.2 releases
- Uses a `pypi` GitHub environment so the publisher can be scoped tightly on the PyPI side

Requires a one-time publisher configuration on pypi.org (owner: `cadentdev`, repo: `wpa`, workflow: `publish.yml`, environment: `pypi`) before the first run.

## Test plan

- [x] `actionlint`-level review by eye; standard pypa publish action pattern
- [ ] After merge + PyPI publisher config: dispatch for v0.8.1 and v0.8.2 and confirm both land on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia