### PR TITLE
chore: drop Python 3.9, single-source version, pin audit tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Weekly run on main so dependency drift is caught by cron,
+    # not by the next feature PR (#48)
+    - cron: "30 5 * * 1"
 
 jobs:
   test:
@@ -14,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
             python-version: "3.12"
@@ -33,12 +37,17 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[dev]'
-          pip install ruff
 
       - name: Lint
         run: |
           ruff check .
           ruff format --check .
+
+      - name: Security audit
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        run: |
+          bandit -r wpa/ -q
+          pip-audit
 
       - name: Test
         run: pytest --cov=wpa --cov-report=term-missing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ ruff check .
 ruff format --check .
 ```
 
-CI runs on ubuntu/macos/windows across Python 3.9, 3.11, 3.12, 3.13. The required status check is `test (ubuntu-latest, 3.12)`.
+CI runs on ubuntu/macos/windows across Python 3.10, 3.11, 3.12, 3.13, plus a weekly scheduled run on `main` to catch dependency drift. The required status check is `test (ubuntu-latest, 3.12)`, which also runs the bandit/pip-audit security step.
 
 ## Architecture
 
@@ -54,13 +54,14 @@ CI runs on ubuntu/macos/windows across Python 3.9, 3.11, 3.12, 3.13. The require
 
 ## Key Conventions
 
-- Python 3.9 minimum — ruff targets `py39`
-- Version string lives in `wpa/__init__.py` AND `pyproject.toml` — bump both (see Release Workflow step 10; #48 will make this single-source)
+- Python 3.10 minimum — ruff targets `py310`
+- Version string lives in `wpa/__init__.py` only — `pyproject.toml` reads it via `dynamic = ["version"]`
+- Lint/audit tools (ruff, bandit, pip-audit) are pinned exactly in the `dev` extra; bump deliberately and fix new findings in the same PR. Runtime deps stay unpinned (upper-bound only known-broken releases)
 - Branch protection on `main` — use feature branches + PRs
 - Command names follow wp-cli conventions (see design principle 4.1 in the PRD)
 - Default status for content creation is always `draft`
 - HTTPS enforced for public addresses; HTTP allowed only for private/LAN
-- Security audits: `bandit` (static analysis) and `pip-audit` (dependency vulnerabilities)
+- Security audits: `bandit` (static analysis) and `pip-audit` (dependency vulnerabilities) run in CI on every PR
 
 ## Release Workflow
 
@@ -81,7 +82,7 @@ Every release follows this arc. Steps 1–3 are planning, 4–6 repeat per PR, 7
 8. **Regression** — full suite + lint + audit tools on the final merged state.
 9. **Docs** — update README, wpa-prd.md (Current release, §6.1 implemented commands, roadmap),
    CLAUDE.md (test count), then RELEASE-NOTES.md last, when scope is final.
-10. **Version bump** — `wpa/__init__.py` AND `pyproject.toml` (until #48 makes it single-source).
+10. **Version bump** — `wpa/__init__.py` (single source; `pyproject.toml` reads it dynamically).
 11. **Ship** — merge the release PR, tag the merge commit `vX.Y.Z`, create the GitHub Release
     (title `vX.Y.Z — Short Name`, body = that version's RELEASE-NOTES.md section). Trusted
     publishing pushes to PyPI automatically.

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -4,7 +4,7 @@ This guide walks through setting up a WordPress site to work with WPA, from veri
 
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.10+
 - A WordPress site (5.6+ for Application Passwords)
 - An Administrator account on the site
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wpa"
-version = "0.8.2"
+dynamic = ["version"]
 description = "WordPress Automation — manage posts, pages, and users via the REST API"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     {name = "Neil Stoker"},
 ]
@@ -18,7 +18,6 @@ classifiers = [
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -27,19 +26,22 @@ classifiers = [
 ]
 dependencies = [
     "requests",
-    # frontmatter 1.2.0+ imports typing.TypeGuard (3.10+) without declaring
-    # requires-python, so pip on 3.9 installs a version that crashes on import
-    "python-frontmatter<1.2; python_version < '3.10'",
-    "python-frontmatter; python_version >= '3.10'",
+    "python-frontmatter",
     "markdown",
     "python-dotenv",
 ]
 
 [project.optional-dependencies]
+# Lint/audit tools are pinned exactly so CI and contributors run identical
+# versions; bump deliberately and fix any new findings in the same PR (#48).
+# Runtime deps stay unpinned so users get patched versions; add an upper
+# bound only when a specific release is known-broken.
 dev = [
     "pytest",
     "pytest-cov",
-    "ruff",
+    "ruff==0.16.2",
+    "bandit==1.9.4",
+    "pip-audit==2.10.1",
 ]
 
 [project.scripts]
@@ -53,8 +55,11 @@ Issues = "https://github.com/cadentdev/wpa/issues"
 [tool.setuptools.packages.find]
 include = ["wpa*"]
 
+[tool.setuptools.dynamic]
+version = {attr = "wpa.__version__"}
+
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/wpa/user.py
+++ b/wpa/user.py
@@ -7,7 +7,8 @@ from wpa.api import build_endpoint
 
 # Character classes for generated passwords. The symbol set is limited to
 # characters that survive shells and the strictest password policies.
-_PASSWORD_SYMBOLS = "!@#$%^*-_+="
+# The nosec suppresses bandit B105 (this alphabet is not a credential).
+_PASSWORD_SYMBOLS = "!@#$%^*-_+="  # nosec B105
 _PASSWORD_ALPHABET = string.ascii_letters + string.digits + _PASSWORD_SYMBOLS
 
 


### PR DESCRIPTION
**v0.9.0 Housekeeping, PR 1 of 3.** Closes #49, closes #48.

## Python 3.9 dropped (#49)

- `requires-python = ">=3.10"`, 3.9 classifier removed, CI matrix now 3.10–3.13, `[tool.ruff] target-version = "py310"`
- The `python-frontmatter<1.2` env-marker cap is removed — it existed solely to protect 3.9 installs
- Supporting data: PyPI download stats show **zero** downloads on 3.9; old releases remain installable there since pip respects `requires-python`

## Dependency hygiene (#48)

- **Version single-sourced:** `dynamic = ["version"]` reads `wpa/__init__.py`; pyproject no longer carries its own copy (verified locally: `python -m build` produces `wpa-0.8.2.tar.gz` from `__version__`). Ends the dual-bump gotcha that caused the 0.8.0/0.8.1 drift.
- **Tooling pinned exactly** in the dev extra (`ruff==0.16.2`, `bandit==1.9.4`, `pip-audit==2.10.1`) so CI and contributors run identical versions; bumps are deliberate, with new findings fixed in the bumping PR. Policy comment recorded in pyproject.
- **Runtime deps stay unpinned** (users get patched versions), upper-bounded only when a release is known-broken.
- **CI security-audit step:** bandit + pip-audit now run on the required ubuntu/3.12 job — enforcement behind Release Workflow step 5. One bandit false positive (B105 on the password-generation symbol alphabet) suppressed with `nosec` + comment.
- **Weekly scheduled CI run** on `main` so drift is caught by cron, not by the next feature PR.

CLAUDE.md and GETTING-STARTED.md updated to match. README badge and PRD floor references are tracked in #52 (docs PR, later this release).

Local verification: 503 tests pass, ruff clean, bandit clean, sdist builds with correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia