### PR TITLE
feat: publish --author + frontmatter author; env-configurable safety caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ wpa page create --site mysite --title "About" --content "<p>About us</p>"
 # Publish shortcut (equivalent to wpa page create with markdown)
 wpa publish pages/your-page.md --site mysite
 
+# Publish attributed to a specific author (or set `author: 15` in
+# frontmatter; the CLI flag wins when both are given)
+wpa publish pages/your-page.md --site mysite --author 15
+
 # Update a page
 wpa page update 42 --site mysite --title "New Title" --parent 10
 
@@ -269,6 +273,7 @@ wpa --version
 title: "Your Page Title"
 slug: "your-page-slug"
 status: draft
+author: 15
 ---
 
 Page content in markdown here...
@@ -277,6 +282,7 @@ Page content in markdown here...
 - `title` (required): Page title
 - `slug` (optional): URL slug
 - `status` (optional): `draft` (default), `publish`, `pending`, or `private`
+- `author` (optional): Author user ID; the `--author` CLI flag overrides it
 
 ### Site config format
 
@@ -291,6 +297,17 @@ WP_ADMIN_PATH=wp-admin
 
 - `WP_ADMIN_PATH` is optional (defaults to `wp-admin`). Override it if your site uses a custom admin URL.
 - The `XDG_CONFIG_HOME` environment variable is respected if set.
+
+### Environment variables
+
+Two protective caps in the API client can be resized per environment:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `WPA_MAX_RESPONSE_BYTES` | `52428800` (50 MB) | Maximum size of a single REST API response |
+| `WPA_MAX_TOTAL_PAGES` | `1000` | Ceiling on pages fetched by paginated list commands |
+
+Invalid values (non-integer, zero, negative) are ignored with a warning and the default applies — a misconfigured environment can resize the caps but never disable them.
 
 ### Migration from repo-root .env
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -509,13 +509,13 @@ class TestSecurityHardening:
 
     @patch("wpa.api.requests.request")
     def test_response_size_over_cap_raises(self, mock_request, client):
-        from wpa.api import MAX_RESPONSE_BYTES
+        from wpa.api import DEFAULT_MAX_RESPONSE_BYTES
 
         resp = MagicMock()
         resp.ok = True
         resp.status_code = 200
         resp.url = "https://example.com/wp-json/wp/v2/posts"
-        resp.content = b"x" * (MAX_RESPONSE_BYTES + 1)
+        resp.content = b"x" * (DEFAULT_MAX_RESPONSE_BYTES + 1)
         mock_request.return_value = resp
 
         with pytest.raises(WPApiError) as exc_info:
@@ -527,13 +527,13 @@ class TestSecurityHardening:
 
     @patch("wpa.api.requests.request")
     def test_response_at_cap_accepted(self, mock_request, client):
-        from wpa.api import MAX_RESPONSE_BYTES
+        from wpa.api import DEFAULT_MAX_RESPONSE_BYTES
 
         resp = MagicMock()
         resp.ok = True
         resp.status_code = 200
         resp.url = "https://example.com/wp-json/wp/v2/posts"
-        resp.content = b"x" * MAX_RESPONSE_BYTES
+        resp.content = b"x" * DEFAULT_MAX_RESPONSE_BYTES
         resp.json.return_value = {"id": 1}
         mock_request.return_value = resp
 
@@ -544,7 +544,7 @@ class TestSecurityHardening:
 
     @patch("wpa.api.requests.get")
     def test_total_pages_clamped(self, mock_get, client):
-        from wpa.api import MAX_TOTAL_PAGES
+        from wpa.api import DEFAULT_MAX_TOTAL_PAGES
 
         resp = MagicMock()
         resp.ok = True
@@ -555,10 +555,10 @@ class TestSecurityHardening:
         resp.headers = {"X-WP-TotalPages": "999999"}
         mock_get.return_value = resp
 
-        # Exhaust the iterator — should stop at MAX_TOTAL_PAGES requests, not 999999.
+        # Exhaust the iterator — should stop at DEFAULT_MAX_TOTAL_PAGES requests, not 999999.
         list(client.get_list("posts"))
-        # First request + (MAX_TOTAL_PAGES - 1) more = MAX_TOTAL_PAGES total.
-        assert mock_get.call_count == MAX_TOTAL_PAGES
+        # First request + (DEFAULT_MAX_TOTAL_PAGES - 1) more = DEFAULT_MAX_TOTAL_PAGES total.
+        assert mock_get.call_count == DEFAULT_MAX_TOTAL_PAGES
 
     @patch("wpa.api.requests.get")
     def test_total_pages_bad_header_defaults_to_one(self, mock_get, client):
@@ -891,3 +891,74 @@ class TestGetTotal:
         mock_get.side_effect = requests.ConnectionError("refused")
         with pytest.raises(WPConnectionError):
             client.get_total("comments")
+
+
+class TestConfigurableCaps:
+    """Tests for env-var-configurable response/pagination caps (#37)."""
+
+    def test_response_cap_default(self):
+        from wpa.api import DEFAULT_MAX_RESPONSE_BYTES, max_response_bytes
+
+        assert max_response_bytes() == DEFAULT_MAX_RESPONSE_BYTES
+
+    def test_total_pages_default(self):
+        from wpa.api import DEFAULT_MAX_TOTAL_PAGES, max_total_pages
+
+        assert max_total_pages() == DEFAULT_MAX_TOTAL_PAGES
+
+    def test_response_cap_env_override(self, monkeypatch):
+        from wpa.api import max_response_bytes
+
+        monkeypatch.setenv("WPA_MAX_RESPONSE_BYTES", "1024")
+        assert max_response_bytes() == 1024
+
+    def test_total_pages_env_override(self, monkeypatch):
+        from wpa.api import max_total_pages
+
+        monkeypatch.setenv("WPA_MAX_TOTAL_PAGES", "5")
+        assert max_total_pages() == 5
+
+    def test_non_integer_env_falls_back_with_warning(self, monkeypatch, capsys):
+        from wpa.api import DEFAULT_MAX_RESPONSE_BYTES, max_response_bytes
+
+        monkeypatch.setenv("WPA_MAX_RESPONSE_BYTES", "lots")
+        assert max_response_bytes() == DEFAULT_MAX_RESPONSE_BYTES
+        assert "WPA_MAX_RESPONSE_BYTES" in capsys.readouterr().err
+
+    def test_non_positive_env_falls_back_with_warning(self, monkeypatch, capsys):
+        from wpa.api import DEFAULT_MAX_TOTAL_PAGES, max_total_pages
+
+        monkeypatch.setenv("WPA_MAX_TOTAL_PAGES", "0")
+        assert max_total_pages() == DEFAULT_MAX_TOTAL_PAGES
+        assert "WPA_MAX_TOTAL_PAGES" in capsys.readouterr().err
+
+    @patch("wpa.api.requests.request")
+    def test_response_cap_env_enforced(self, mock_request, client, monkeypatch):
+        monkeypatch.setenv("WPA_MAX_RESPONSE_BYTES", "10")
+
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.url = "https://example.com/wp-json/wp/v2/posts"
+        resp.content = b"x" * 11
+        mock_request.return_value = resp
+
+        with pytest.raises(WPApiError) as exc_info:
+            client.get("posts")
+        assert exc_info.value.code == "response_too_large"
+
+    @patch("wpa.api.requests.get")
+    def test_total_pages_env_enforced(self, mock_get, client, monkeypatch):
+        monkeypatch.setenv("WPA_MAX_TOTAL_PAGES", "3")
+
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.url = "https://example.com/wp-json/wp/v2/posts"
+        resp.content = b"[]"
+        resp.json.return_value = []
+        resp.headers = {"X-WP-TotalPages": "999999"}
+        mock_get.return_value = resp
+
+        list(client.get_list("posts"))
+        assert mock_get.call_count == 3

--- a/tests/test_wp_publish.py
+++ b/tests/test_wp_publish.py
@@ -208,6 +208,24 @@ class TestPublishPage:
         data = mock_client.post.call_args[1]["data"]
         assert "slug" not in data
 
+    def test_author_included_in_payload(self, mock_client):
+        """publish_page sends author when one is given."""
+        mock_client.post.return_value = {"id": 1}
+
+        publish_page(mock_client, "Title", "", "draft", "<p>Content</p>", author=15)
+
+        data = mock_client.post.call_args[1]["data"]
+        assert data["author"] == 15
+
+    def test_author_omitted_when_none(self, mock_client):
+        """publish_page leaves author out of the payload by default."""
+        mock_client.post.return_value = {"id": 1}
+
+        publish_page(mock_client, "Title", "", "draft", "<p>Content</p>")
+
+        data = mock_client.post.call_args[1]["data"]
+        assert "author" not in data
+
     def test_api_error_returns_one(self, mock_client, capsys):
         """publish_page returns 1 and prints error on API error."""
         mock_client.post.side_effect = WPApiError(
@@ -1117,14 +1135,15 @@ class TestResolveFileFields:
         }
 
     def test_frontmatter_only(self):
-        title, content, status, slug = resolve_file_fields(self._file_data())
+        title, content, status, slug, author = resolve_file_fields(self._file_data())
         assert title == "From File"
         assert content == "<p>Body</p>"
         assert status == "publish"
         assert slug == "from-file"
+        assert author is None
 
     def test_cli_flags_override_frontmatter(self):
-        title, content, status, slug = resolve_file_fields(
+        title, content, status, slug, _author = resolve_file_fields(
             self._file_data(), title="CLI Title", status="draft", slug="cli-slug"
         )
         assert title == "CLI Title"
@@ -1134,9 +1153,35 @@ class TestResolveFileFields:
         assert content == "<p>Body</p>"
 
     def test_defaults_when_frontmatter_sparse(self):
-        title, _content, status, slug = resolve_file_fields(
+        title, _content, status, slug, author = resolve_file_fields(
             {"title": "Minimal", "slug": "", "status": "", "content": "<p>x</p>"}
         )
         assert title == "Minimal"
         assert status == "draft"
         assert slug is None
+        assert author is None
+
+    def test_author_from_frontmatter(self):
+        data = {**self._file_data(), "author": 15}
+        *_rest, author = resolve_file_fields(data)
+        assert author == 15
+
+    def test_cli_author_overrides_frontmatter(self):
+        data = {**self._file_data(), "author": 15}
+        *_rest, author = resolve_file_fields(data, author=20)
+        assert author == 20
+
+    def test_author_string_digits_coerced_to_int(self):
+        data = {**self._file_data(), "author": "15"}
+        *_rest, author = resolve_file_fields(data)
+        assert author == 15
+
+    def test_author_non_numeric_raises(self):
+        data = {**self._file_data(), "author": "jane"}
+        with pytest.raises(ValueError, match="author"):
+            resolve_file_fields(data)
+
+    def test_author_non_positive_raises(self):
+        data = {**self._file_data(), "author": 0}
+        with pytest.raises(ValueError, match="author"):
+            resolve_file_fields(data)

--- a/wpa/api.py
+++ b/wpa/api.py
@@ -1,6 +1,7 @@
 """Shared REST API client for all WPA commands."""
 
 import base64
+import os
 import re
 import sys
 
@@ -18,8 +19,43 @@ _ERROR_MESSAGES = {
 
 # Defense-in-depth caps against hostile / buggy upstream responses.
 # Tuned for "WP REST API payloads that any reasonable site produces."
-MAX_RESPONSE_BYTES = 50 * 1024 * 1024  # 50 MB — any single response
-MAX_TOTAL_PAGES = 1000  # pagination ceiling regardless of X-WP-TotalPages
+# Overridable per-environment via WPA_MAX_RESPONSE_BYTES / WPA_MAX_TOTAL_PAGES.
+DEFAULT_MAX_RESPONSE_BYTES = 50 * 1024 * 1024  # 50 MB — any single response
+DEFAULT_MAX_TOTAL_PAGES = 1000  # pagination ceiling regardless of X-WP-TotalPages
+
+
+def _env_cap(name, default):
+    """Read a positive-int cap from the environment, falling back to default.
+
+    Invalid values (non-integer, zero, negative) warn on stderr and keep the
+    default so a misconfigured environment can never disable the cap.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        value = 0
+    if value < 1:
+        print(
+            f"Warning: ignoring {name}={raw!r} (expected a positive integer); "
+            f"using {default}",
+            file=sys.stderr,
+        )
+        return default
+    return value
+
+
+def max_response_bytes():
+    """Response-size cap in bytes (WPA_MAX_RESPONSE_BYTES or default)."""
+    return _env_cap("WPA_MAX_RESPONSE_BYTES", DEFAULT_MAX_RESPONSE_BYTES)
+
+
+def max_total_pages():
+    """Pagination ceiling (WPA_MAX_TOTAL_PAGES or default)."""
+    return _env_cap("WPA_MAX_TOTAL_PAGES", DEFAULT_MAX_TOTAL_PAGES)
+
 
 # Endpoint path sanitizer — defense-in-depth against traversal. All legitimate
 # WP REST endpoints are ASCII slugs with optional numeric IDs and literal
@@ -194,16 +230,17 @@ class WPApiClient:
             )
 
     def _check_response_size(self, response):
-        """Raise WPApiError if the response body exceeds MAX_RESPONSE_BYTES."""
+        """Raise WPApiError if the response body exceeds the size cap."""
         # Content-Length is advisory; check actual bytes too. requests has
         # already read the body at this point (we don't use stream=True), so
         # len(response.content) is authoritative.
-        if len(response.content) > MAX_RESPONSE_BYTES:
+        cap = max_response_bytes()
+        if len(response.content) > cap:
             raise WPApiError(
                 response.status_code,
                 "response_too_large",
                 f"Response from {self.site_url} exceeded "
-                f"{MAX_RESPONSE_BYTES} bytes ({len(response.content)} bytes).",
+                f"{cap} bytes ({len(response.content)} bytes).",
             )
 
     def _check_no_scheme_downgrade(self, response):
@@ -457,14 +494,14 @@ class WPApiClient:
 
         yield from data
 
-        # Check for additional pages — clamp to MAX_TOTAL_PAGES to defend
+        # Check for additional pages — clamp to the pagination cap to defend
         # against a hostile or buggy server that returns an absurd
         # X-WP-TotalPages value (e.g., 999999) and forces an infinite loop.
         try:
             total_pages = int(response.headers.get("X-WP-TotalPages", 1))
         except (TypeError, ValueError):
             total_pages = 1
-        total_pages = min(total_pages, MAX_TOTAL_PAGES)
+        total_pages = min(total_pages, max_total_pages())
 
         for page_num in range(2, total_pages + 1):
             page_params = {**params, "page": page_num}

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -57,7 +57,7 @@ from wpa.post import (
 from wpa.post import (
     validate_fields as validate_post_fields,
 )
-from wpa.publish import parse_markdown, parse_page, publish_page, resolve_file_fields
+from wpa.publish import parse_markdown, publish_page, resolve_file_fields
 from wpa.term import (
     create_term,
     delete_term,
@@ -162,12 +162,26 @@ def _format_list_output(rows, fields, args):  # pragma: no cover
 
 def _do_publish(args):  # pragma: no cover
     """Publish a markdown file as a WordPress page."""
-    title, slug, status, content = parse_page(args.file)
+    try:
+        data = parse_markdown(args.file)
+        # Frontmatter supplies author too; --author wins when both are given.
+        title, content, status, slug, author = resolve_file_fields(
+            data, author=args.author
+        )
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
     client = WPApiClient.from_config(site_name=args.site)
 
     print(f"Publishing '{title}' as {status} to {client.site_url}...")
     return publish_page(
-        client, title, slug, status, content, admin_path=client.admin_path
+        client,
+        title,
+        slug,
+        status,
+        content,
+        admin_path=client.admin_path,
+        author=author,
     )
 
 
@@ -259,17 +273,22 @@ def _do_post_create(args):  # pragma: no cover
             tags = [int(t.strip()) for t in args.tags.split(",")]
 
         if args.file:
-            # Markdown file: frontmatter supplies title/status/slug and the
-            # body converts to HTML; explicit CLI flags win over frontmatter.
+            # Markdown file: frontmatter supplies title/status/slug/author and
+            # the body converts to HTML; explicit CLI flags win over frontmatter.
             data = parse_markdown(args.file)
-            title, content, status, slug = resolve_file_fields(
-                data, title=args.title, status=args.status, slug=args.slug
+            title, content, status, slug, author = resolve_file_fields(
+                data,
+                title=args.title,
+                status=args.status,
+                slug=args.slug,
+                author=args.author,
             )
         else:
             title = args.title
             content = args.content or ""
             status = args.status or "draft"
             slug = args.slug
+            author = args.author
 
         result = create_post(
             client,
@@ -277,7 +296,7 @@ def _do_post_create(args):  # pragma: no cover
             content=content,
             status=status,
             slug=slug,
-            author=args.author,
+            author=author,
             categories=categories,
             tags=tags,
             featured_media=args.featured_media,
@@ -404,17 +423,22 @@ def _do_page_create(args, file_path=None):  # pragma: no cover
         client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
 
         if file_path:
-            # Frontmatter supplies title/status/slug and the body converts
-            # to HTML; explicit CLI flags win over frontmatter.
+            # Frontmatter supplies title/status/slug/author and the body
+            # converts to HTML; explicit CLI flags win over frontmatter.
             data = parse_markdown(file_path)
-            title, content, status, slug = resolve_file_fields(
-                data, title=args.title, status=args.status, slug=args.slug
+            title, content, status, slug, author = resolve_file_fields(
+                data,
+                title=args.title,
+                status=args.status,
+                slug=args.slug,
+                author=args.author,
             )
         else:
             title = args.title
             content = args.content or ""
             status = args.status or "draft"
             slug = args.slug
+            author = args.author
 
         result = create_page(
             client,
@@ -423,7 +447,7 @@ def _do_page_create(args, file_path=None):  # pragma: no cover
             status=status,
             slug=slug,
             parent=args.parent,
-            author=args.author,
+            author=author,
             menu_order=args.menu_order,
         )
         print("Page created successfully!")
@@ -1104,6 +1128,11 @@ def main(argv=None):
     )
     publish_parser.add_argument(
         "--site", help="Use named site config from ~/.config/wpa/<name>/"
+    )
+    publish_parser.add_argument(
+        "--author",
+        type=int,
+        help="Author user ID (overrides frontmatter 'author')",
     )
     publish_parser.set_defaults(func=_do_publish)
 

--- a/wpa/publish.py
+++ b/wpa/publish.py
@@ -74,32 +74,58 @@ def parse_page(filepath):
     return data["title"], data["slug"], data["status"], data["content"]
 
 
-def resolve_file_fields(file_data, title=None, status=None, slug=None):
+def resolve_file_fields(file_data, title=None, status=None, slug=None, author=None):
     """Merge markdown-file fields with CLI flag overrides.
 
-    Used by `post create --file` / `page create --file`: the file's YAML
-    frontmatter supplies title/status/slug and the converted HTML body,
-    and any CLI flag that was explicitly passed wins over frontmatter.
+    Used by `publish` and `post create --file` / `page create --file`: the
+    file's YAML frontmatter supplies title/status/slug/author and the
+    converted HTML body, and any CLI flag that was explicitly passed wins
+    over frontmatter.
 
     Args:
-        file_data: Dict from parse_markdown() (title, slug, status, content).
+        file_data: Dict from parse_markdown() (title, slug, status, content,
+            and optionally author).
         title: CLI --title override, or None.
         status: CLI --status override, or None.
         slug: CLI --slug override, or None.
+        author: CLI --author override, or None.
 
     Returns:
-        Tuple of (title, content, status, slug) with overrides applied.
-        status falls back to 'draft', slug to None when empty.
+        Tuple of (title, content, status, slug, author) with overrides
+        applied. status falls back to 'draft', slug to None when empty,
+        author to None when absent.
+
+    Raises:
+        ValueError: If the frontmatter author is not a positive integer.
     """
+    if author is None:
+        author = file_data.get("author")
+    if author is not None:
+        try:
+            author = int(author)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Frontmatter 'author' must be a user ID "
+                f"(positive integer), got {author!r}"
+            ) from None
+        if author < 1:
+            raise ValueError(
+                f"Frontmatter 'author' must be a user ID "
+                f"(positive integer), got {author!r}"
+            )
+
     return (
         title or file_data.get("title"),
         file_data.get("content", ""),
         status or file_data.get("status") or "draft",
         slug or file_data.get("slug") or None,
+        author,
     )
 
 
-def publish_page(client, title, slug, status, content, admin_path="wp-admin"):
+def publish_page(
+    client, title, slug, status, content, admin_path="wp-admin", author=None
+):
     """POST a page to WordPress REST API using WPApiClient.
 
     Args:
@@ -109,6 +135,7 @@ def publish_page(client, title, slug, status, content, admin_path="wp-admin"):
         status: Publication status.
         content: HTML content.
         admin_path: WordPress admin path (default: wp-admin).
+        author: Author user ID, or None to use the authenticated user.
 
     Returns:
         0 on success, 1 on error.
@@ -120,6 +147,8 @@ def publish_page(client, title, slug, status, content, admin_path="wp-admin"):
     }
     if slug:
         payload["slug"] = slug
+    if author is not None:
+        payload["author"] = author
 
     try:
         data = client.post("pages", data=payload)


### PR DESCRIPTION
**v0.9.0 Housekeeping, PR 2 of 3.** Closes #26, closes #37.

## `--author` for markdown publishing (#26)

- `wpa publish` gains `--author AUTHOR_ID`, and the `author:` frontmatter field now applies everywhere markdown input is accepted: `publish`, `post create --file`, `page create --file`. The CLI flag wins when both are given — same precedence rule as title/status/slug.
- `resolve_file_fields()` validates author as a positive integer (YAML `author: jane` gets a clear error, not a 500 from WordPress) and returns it as a fifth field; `publish_page()` forwards it to the REST payload only when set.
- Note: since v0.8.2, `page create --file file.md --author 15` already covered the issue's core workaround; this PR closes the remaining gap (`publish` itself + frontmatter support).

## Env-configurable safety caps (#37, audit finding M2)

- `WPA_MAX_RESPONSE_BYTES` (default 50 MB) and `WPA_MAX_TOTAL_PAGES` (default 1000) now override the v0.8.0 hardening caps per environment.
- **Fail-safe parsing:** invalid values (non-integer, zero, negative) warn on stderr and keep the default — a misconfigured environment can resize the caps but never disable them. Caps are read at use time, so no import-order surprises.
- Constants renamed `MAX_*` → `DEFAULT_MAX_*` (internal only). CLI flags from the issue's "optionally" list were skipped deliberately — env vars satisfy the acceptance criteria without widening every subcommand's surface.
- Not implemented as CLI flags per simplest-solution principle; can be added later if a use case appears.

## Tests (TDD)

15 new tests written first (RED), then implementation (GREEN): author resolution/override/validation, payload inclusion/omission, env override, fail-safe fallback with warning, and functional enforcement of both env caps through `get`/`get_list`. **518 total**, ruff + bandit clean.

README documents the flag, the frontmatter field, and the env knobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia