### PR TITLE
fix: reject YAML bool/float author values instead of coercing to user 1

### DIFF
--- a/tests/test_wp_publish.py
+++ b/tests/test_wp_publish.py
@@ -1185,3 +1185,15 @@ class TestResolveFileFields:
         data = {**self._file_data(), "author": 0}
         with pytest.raises(ValueError, match="author"):
             resolve_file_fields(data)
+
+    def test_author_bool_raises(self):
+        # YAML `author: true` must not silently become user ID 1
+        data = {**self._file_data(), "author": True}
+        with pytest.raises(ValueError, match="author"):
+            resolve_file_fields(data)
+
+    def test_author_float_raises(self):
+        # YAML `author: 1.9` must not silently truncate to user ID 1
+        data = {**self._file_data(), "author": 1.9}
+        with pytest.raises(ValueError, match="author"):
+            resolve_file_fields(data)

--- a/wpa/publish.py
+++ b/wpa/publish.py
@@ -101,8 +101,10 @@ def resolve_file_fields(file_data, title=None, status=None, slug=None, author=No
     if author is None:
         author = file_data.get("author")
     if author is not None:
+        # Coerce via str so YAML booleans ("True") and floats ("1.9") are
+        # rejected instead of silently becoming user ID 1 via int().
         try:
-            author = int(author)
+            author = int(str(author))
         except (TypeError, ValueError):
             raise ValueError(
                 f"Frontmatter 'author' must be a user ID "


### PR DESCRIPTION
**v0.9.0 Housekeeping — release-audit fix (workflow steps 7–8).**

Reviewing the full v0.8.2→main diff surfaced one defect in the new #26 code: `resolve_file_fields` coerced the frontmatter author with `int()`, which accepts more than intended:

- `author: true` → `int(True)` → **user ID 1** — YAML treats `true`/`yes` as booleans, and bool is an int subclass, so content would be silently attributed to the admin account
- `author: 1.9` → `int(1.9)` → **user ID 1** — silent float truncation

Coercing via `int(str(author))` rejects both with the existing clear error message while still accepting ints and digit strings. Two regression tests added — **520 total**, ruff/bandit clean.

No other findings: the env-cap parsing is fail-safe (invalid values keep the protective default), the caps are read at use time with no import-order dependence, `--author` is argparse-validated as int, and WordPress enforces author-assignment capability server-side per the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia