### PR TITLE
feat: wpa plugin — list, get, activate, deactivate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,10 @@ Every release follows this arc. Steps 1–3 are planning, 4–6 repeat per PR, 7
    approved before implementation starts.
 4. **TDD loop (per PR)** — write failing tests for the new behavior first, implement until GREEN,
    refactor. Coverage stays ≥98%; only thin CLI adapter functions may use `# pragma: no cover`.
-5. **CI green (per PR)** — full matrix passes, including ruff, bandit, and pip-audit.
+5. **CI green (per PR)** — full matrix passes, including ruff, bandit, and pip-audit. Timing notes:
+   `gh pr checks <n> --watch` reports "no checks" if run within seconds of PR creation — wait ~30s
+   first. Stacked PRs (base ≠ main) get no CI runs at all until rebased onto main after their base
+   merges; ci.yml only triggers on PRs targeting main.
 6. **Merge (per PR)** — merge-commit strategy (not squash). Surface discovered smells as new issues
    rather than widening the PR.
 7. **Security audit** — human review of the full release diff (not just tool output). File findings

--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ wpa comment delete 123 --site mysite
 wpa comment delete 123 --site mysite --force
 ```
 
+### Manage plugins
+
+Requires an account with the `activate_plugins` capability (administrator on most installs).
+
+```bash
+# List installed plugins (all statuses by default)
+wpa plugin list --site mysite
+wpa plugin list --site mysite --status active
+wpa plugin list --site mysite --search "cache" --format json
+
+# Get a single plugin (folder/file identifier; .php suffix accepted)
+wpa plugin get akismet/akismet --site mysite
+
+# Activate / deactivate
+wpa plugin activate akismet/akismet --site mysite
+wpa plugin deactivate akismet/akismet --site mysite
+```
+
+Installing, updating, and deleting plugins are not supported yet — install/delete are planned (see issue #41's follow-ups); updating to a newer version is a REST API limitation, so use wp-admin or wp-cli for that.
+
 ### Manage taxonomy terms (categories, tags, custom)
 
 ```bash

--- a/examples/bootstrap-site.sh
+++ b/examples/bootstrap-site.sh
@@ -706,7 +706,50 @@ wpa term delete "${TAG2_ID}" --site "${SITE}" --taxonomy post_tag
 echo
 
 # =============================================================================
-# 7. SUMMARY
+# 7. PLUGINS  (v0.10.0)
+# =============================================================================
+# Exercises the following wpa subcommands:
+#
+#   - wpa plugin list        (NEW in v0.10.0 — with --status filter)
+#   - wpa plugin get         (NEW in v0.10.0)
+#   - wpa plugin deactivate  (NEW in v0.10.0)
+#   - wpa plugin activate    (NEW in v0.10.0)
+#
+# The round-trip (list → deactivate → activate → confirm) is idempotent:
+# it targets a plugin that is known-installed and known-active on the
+# rollback baseline, and ends with the plugin active again. Requires the
+# authenticated user to have the activate_plugins capability (admin).
+#
+# SMOKE_PLUGIN defaults to Akismet, which ships with stock WordPress.
+# Override for targets with a different baseline:
+#   SMOKE_PLUGIN="wordfence/wordfence" ./bootstrap-site.sh ...
+SMOKE_PLUGIN="${SMOKE_PLUGIN:-akismet/akismet}"
+
+echo "=== 7. Plugins ==="
+echo
+
+echo "Listing installed plugins..."
+wpa plugin list --site "${SITE}"
+echo
+
+echo "Fetching plugin ${SMOKE_PLUGIN}..."
+wpa plugin get "${SMOKE_PLUGIN}" --site "${SITE}"
+echo
+
+echo "Deactivating ${SMOKE_PLUGIN}..."
+wpa plugin deactivate "${SMOKE_PLUGIN}" --site "${SITE}"
+echo
+
+echo "Re-activating ${SMOKE_PLUGIN}..."
+wpa plugin activate "${SMOKE_PLUGIN}" --site "${SITE}"
+echo
+
+echo "Confirming via active-only listing (should include ${SMOKE_PLUGIN})..."
+wpa plugin list --site "${SITE}" --status active
+echo
+
+# =============================================================================
+# 8. SUMMARY
 # =============================================================================
 
 echo "============================================================"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,194 @@
+"""Tests for wpa.plugin — plugin listing and activation management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.plugin import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    _extract_plugin_row,
+    activate_plugin,
+    deactivate_plugin,
+    get_plugin,
+    list_plugins,
+    normalize_plugin_id,
+    update_plugin,
+    validate_fields,
+)
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+SAMPLE_API_PLUGIN = {
+    "plugin": "akismet/akismet",
+    "status": "active",
+    "name": "Akismet Anti-spam",
+    "version": "5.3.1",
+    "author": "Automattic",
+    "description": {
+        "raw": "Spam protection for your site.",
+        "rendered": "<p>Spam protection for your site.</p>",
+    },
+    "requires_wp": "5.8",
+    "requires_php": "5.6.20",
+    "network_only": False,
+    "auto_update": False,
+    "_links": {},
+}
+
+
+class TestNormalizePluginId:
+    def test_folder_file_passes_through(self):
+        assert normalize_plugin_id("akismet/akismet") == "akismet/akismet"
+
+    def test_php_extension_stripped(self):
+        # wp-cli convention accepts folder/file.php; REST wants no extension
+        assert normalize_plugin_id("akismet/akismet.php") == "akismet/akismet"
+
+    def test_single_segment_accepted(self):
+        # Single-file plugins are addressed by bare slug
+        assert normalize_plugin_id("hello") == "hello"
+
+    def test_invalid_empty_raises(self):
+        with pytest.raises(ValueError, match="plugin"):
+            normalize_plugin_id("")
+
+    def test_invalid_traversal_raises(self):
+        with pytest.raises(ValueError, match="plugin"):
+            normalize_plugin_id("../evil")
+
+    def test_invalid_three_segments_raises(self):
+        with pytest.raises(ValueError, match="plugin"):
+            normalize_plugin_id("a/b/c")
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(ValueError, match="plugin"):
+            normalize_plugin_id(None)
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("plugin,status") == ["plugin", "status"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("plugin,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestExtractPluginRow:
+    def test_flattens_description_to_raw(self):
+        row = _extract_plugin_row(SAMPLE_API_PLUGIN)
+        assert row["description"] == "Spam protection for your site."
+
+    def test_friendly_keys_present(self):
+        row = _extract_plugin_row(SAMPLE_API_PLUGIN)
+        assert row["plugin"] == "akismet/akismet"
+        assert row["status"] == "active"
+        assert row["name"] == "Akismet Anti-spam"
+        assert row["version"] == "5.3.1"
+        assert row["auto_update"] is False
+
+    def test_missing_keys_default_empty(self):
+        row = _extract_plugin_row({"plugin": "hello"})
+        assert row["name"] == ""
+        assert row["description"] == ""
+
+
+class TestListPlugins:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_PLUGIN]
+        rows = list_plugins(mock_client)
+        assert rows == [_extract_plugin_row(SAMPLE_API_PLUGIN)]
+        mock_client.get.assert_called_once_with("plugins", params={"context": "edit"})
+
+    def test_status_filter(self, mock_client):
+        mock_client.get.return_value = []
+        list_plugins(mock_client, status="inactive")
+        params = mock_client.get.call_args[1]["params"]
+        assert params["status"] == "inactive"
+
+    def test_status_all_sends_no_filter(self, mock_client):
+        mock_client.get.return_value = []
+        list_plugins(mock_client, status="all")
+        params = mock_client.get.call_args[1]["params"]
+        assert "status" not in params
+
+    def test_invalid_status_raises(self, mock_client):
+        with pytest.raises(ValueError, match="status"):
+            list_plugins(mock_client, status="enabled")
+
+    def test_search_filter(self, mock_client):
+        mock_client.get.return_value = []
+        list_plugins(mock_client, search="spam")
+        params = mock_client.get.call_args[1]["params"]
+        assert params["search"] == "spam"
+
+    def test_non_list_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = {"unexpected": "shape"}
+        assert list_plugins(mock_client) == []
+
+
+class TestGetPlugin:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_PLUGIN
+        row = get_plugin(mock_client, "akismet/akismet")
+        assert row["plugin"] == "akismet/akismet"
+        mock_client.get.assert_called_once_with(
+            "plugins/akismet/akismet", params={"context": "edit"}
+        )
+
+    def test_get_normalizes_php_extension(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_PLUGIN
+        get_plugin(mock_client, "akismet/akismet.php")
+        endpoint = mock_client.get.call_args[0][0]
+        assert endpoint == "plugins/akismet/akismet"
+
+    def test_get_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="plugin"):
+            get_plugin(mock_client, "a/b/c")
+        mock_client.get.assert_not_called()
+
+
+class TestUpdatePlugin:
+    def test_activate_posts_status(self, mock_client):
+        mock_client.post.return_value = {**SAMPLE_API_PLUGIN, "status": "active"}
+        result = activate_plugin(mock_client, "akismet/akismet")
+        mock_client.post.assert_called_once_with(
+            "plugins/akismet/akismet", data={"status": "active"}
+        )
+        assert result["status"] == "active"
+
+    def test_deactivate_posts_status(self, mock_client):
+        mock_client.post.return_value = {**SAMPLE_API_PLUGIN, "status": "inactive"}
+        result = deactivate_plugin(mock_client, "akismet/akismet")
+        mock_client.post.assert_called_once_with(
+            "plugins/akismet/akismet", data={"status": "inactive"}
+        )
+        assert result["status"] == "inactive"
+
+    def test_update_invalid_status_raises(self, mock_client):
+        with pytest.raises(ValueError, match="status"):
+            update_plugin(mock_client, "akismet/akismet", status="enabled")
+        mock_client.post.assert_not_called()
+
+    def test_update_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="plugin"):
+            update_plugin(mock_client, "../evil", status="active")
+        mock_client.post.assert_not_called()
+
+    def test_single_segment_plugin(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_PLUGIN
+        activate_plugin(mock_client, "hello")
+        endpoint = mock_client.post.call_args[0][0]
+        assert endpoint == "plugins/hello"

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -47,6 +47,15 @@ from wpa.page import (
 from wpa.page import (
     validate_fields as validate_page_fields,
 )
+from wpa.plugin import (
+    activate_plugin,
+    deactivate_plugin,
+    get_plugin,
+    list_plugins,
+)
+from wpa.plugin import (
+    validate_fields as validate_plugin_fields,
+)
 from wpa.post import (
     create_post,
     delete_post,
@@ -776,6 +785,67 @@ def _do_media_delete(args):  # pragma: no cover
 # --- Comment handlers ---
 
 
+def _do_plugin_list(args):  # pragma: no cover
+    """List installed WordPress plugins."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_plugin_fields(args.fields)
+        rows = list_plugins(client, status=args.status, search=args.search)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_plugin_get(args):  # pragma: no cover
+    """Get a single installed plugin."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_plugin(client, args.plugin)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_plugin_toggle(action_func, action_label):  # pragma: no cover
+    """Build an activate/deactivate handler that prints the new status."""
+
+    def handler(args):
+        try:
+            client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+            result = action_func(client, args.plugin)
+            print(
+                f"Plugin {result.get('plugin', args.plugin)} {action_label} "
+                f"(status: {result.get('status', '')})."
+            )
+            return 0
+        except ValueError as e:
+            print(f"Error: {e}")
+            return 1
+        except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+            return _handle_api_error(e)
+
+    return handler
+
+
+def _do_plugin_activate(args):  # pragma: no cover
+    return _do_plugin_toggle(activate_plugin, "activated")(args)
+
+
+def _do_plugin_deactivate(args):  # pragma: no cover
+    return _do_plugin_toggle(deactivate_plugin, "deactivated")(args)
+
+
 def _do_comment_list(args):  # pragma: no cover
     """List WordPress comments."""
     try:
@@ -1502,6 +1572,54 @@ def main(argv=None):
         help="Permanently delete (skip trash)",
     )
     media_delete_parser.set_defaults(func=_do_media_delete)
+
+    # --- wpa plugin ---
+    plugin_parser = subparsers.add_parser(
+        "plugin",
+        help="Plugin management commands (requires activate_plugins capability)",
+    )
+    plugin_subparsers = plugin_parser.add_subparsers(dest="plugin_command")
+
+    # wpa plugin list
+    plugin_list_parser = plugin_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List installed plugins"
+    )
+    plugin_list_parser.add_argument(
+        "--status",
+        choices=["active", "inactive", "all"],
+        default="all",
+        help="Filter by activation status (default: all)",
+    )
+    plugin_list_parser.add_argument("--search", help="Search installed plugins")
+    plugin_list_parser.set_defaults(func=_do_plugin_list)
+
+    # wpa plugin get <plugin>
+    plugin_get_parser = plugin_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single installed plugin"
+    )
+    plugin_get_parser.add_argument(
+        "plugin", help="Plugin identifier (e.g. akismet/akismet)"
+    )
+    plugin_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    plugin_get_parser.set_defaults(func=_do_plugin_get)
+
+    # wpa plugin activate/deactivate <plugin>
+    for action_name, action_func, help_text in (
+        ("activate", _do_plugin_activate, "Activate an installed plugin"),
+        ("deactivate", _do_plugin_deactivate, "Deactivate an installed plugin"),
+    ):
+        action_parser = plugin_subparsers.add_parser(
+            action_name, parents=[shared], help=help_text
+        )
+        action_parser.add_argument(
+            "plugin", help="Plugin identifier (e.g. akismet/akismet)"
+        )
+        action_parser.set_defaults(func=action_func)
 
     # --- wpa comment ---
     comment_parser = subparsers.add_parser(

--- a/wpa/plugin.py
+++ b/wpa/plugin.py
@@ -1,0 +1,194 @@
+"""Plugin management via WordPress REST API.
+
+Covers `/wp/v2/plugins` — list, get, activate, deactivate. Requires an
+authenticated user with the `activate_plugins` capability (administrator on
+most installs). Install/delete are deliberately not implemented yet (#41
+defers them to follow-up issues).
+"""
+
+from wpa.api import build_endpoint
+
+# Plugin identifiers are "folder/file" (e.g. "akismet/akismet") or a bare
+# slug for single-file plugins. wp-cli also accepts "folder/file.php"; the
+# REST API wants the identifier without the extension.
+PLUGIN_STATUSES = ("active", "inactive")
+
+# Maps friendly field names to WordPress REST API response keys
+PLUGIN_FIELDS = {
+    "plugin": "plugin",
+    "name": "name",
+    "status": "status",
+    "version": "version",
+    "author": "author",
+    "description": "description",
+    "requires_wp": "requires_wp",
+    "requires_php": "requires_php",
+    "network_only": "network_only",
+    "auto_update": "auto_update",
+}
+
+AVAILABLE_FIELDS = list(PLUGIN_FIELDS.keys())
+DEFAULT_FIELDS = ["plugin", "name", "status", "version"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in PLUGIN_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def normalize_plugin_id(plugin_id):
+    """Normalize a plugin identifier to the REST API's expected shape.
+
+    Accepts "folder/file", "folder/file.php" (wp-cli convention), or a bare
+    slug for single-file plugins, and validates each path segment so an
+    identifier sourced from user input can never smuggle traversal into the
+    endpoint.
+
+    Args:
+        plugin_id: Plugin identifier string.
+
+    Returns:
+        Normalized identifier (e.g. 'akismet/akismet' or 'hello').
+
+    Raises:
+        ValueError: If the identifier is empty, has more than two segments,
+            or any segment is invalid.
+    """
+    if not isinstance(plugin_id, str) or not plugin_id:
+        raise ValueError(f"Invalid plugin identifier: {plugin_id!r}")
+
+    plugin_id = plugin_id.removesuffix(".php")
+
+    segments = plugin_id.split("/")
+    if len(segments) > 2:
+        raise ValueError(f"Invalid plugin identifier: {plugin_id!r}")
+
+    # build_endpoint validates each segment (slug shape, no traversal) and
+    # raises ValueError mentioning the offending segment; re-raise with the
+    # plugin framing callers expect.
+    try:
+        build_endpoint(*segments)
+    except ValueError:
+        raise ValueError(f"Invalid plugin identifier: {plugin_id!r}") from None
+
+    return "/".join(segments)
+
+
+def _plugin_endpoint(plugin_id):
+    """Build the validated endpoint for a single plugin."""
+    normalized = normalize_plugin_id(plugin_id)
+    return build_endpoint("plugins", *normalized.split("/"))
+
+
+def _extract_plugin_row(api_plugin):
+    """Convert a WP REST API plugin object to a flat dict with friendly keys."""
+    row = {}
+    for friendly, api_key in PLUGIN_FIELDS.items():
+        value = api_plugin.get(api_key, "")
+        if friendly == "description" and isinstance(value, dict):
+            value = value.get("raw", "")
+        row[friendly] = value
+    return row
+
+
+def list_plugins(client, status=None, search=None):
+    """Fetch installed plugins.
+
+    Note: `/wp/v2/plugins` is not paginated — WordPress returns every
+    installed plugin in one response, so there is no per_page handling.
+
+    Args:
+        client: WPApiClient instance.
+        status: Filter by 'active' or 'inactive'; 'all' or None for no filter.
+        search: Search installed plugins' metadata.
+
+    Returns:
+        List of plugin dicts with friendly field names.
+
+    Raises:
+        ValueError: If status is not one of active, inactive, all.
+    """
+    params = {"context": "edit"}
+    if status is not None and status != "all":
+        if status not in PLUGIN_STATUSES:
+            raise ValueError(
+                f"Invalid status '{status}'. "
+                f"Must be one of: {', '.join(PLUGIN_STATUSES)}, all"
+            )
+        params["status"] = status
+    if search:
+        params["search"] = search
+
+    data = client.get("plugins", params=params)
+    if not isinstance(data, list):
+        return []
+    return [_extract_plugin_row(p) for p in data]
+
+
+def get_plugin(client, plugin_id):
+    """Get a single installed plugin.
+
+    Args:
+        client: WPApiClient instance.
+        plugin_id: Plugin identifier ('folder/file', 'folder/file.php',
+            or bare slug).
+
+    Returns:
+        Plugin dict with friendly field names.
+    """
+    endpoint = _plugin_endpoint(plugin_id)
+    data = client.get(endpoint, params={"context": "edit"})
+    return _extract_plugin_row(data)
+
+
+def update_plugin(client, plugin_id, status):
+    """Set a plugin's activation status.
+
+    Args:
+        client: WPApiClient instance.
+        plugin_id: Plugin identifier.
+        status: 'active' or 'inactive'.
+
+    Returns:
+        Updated plugin dict with friendly field names.
+
+    Raises:
+        ValueError: If status is invalid or the identifier is malformed.
+    """
+    if status not in PLUGIN_STATUSES:
+        raise ValueError(
+            f"Invalid status '{status}'. Must be one of: {', '.join(PLUGIN_STATUSES)}"
+        )
+    endpoint = _plugin_endpoint(plugin_id)
+    data = client.post(endpoint, data={"status": status})
+    return _extract_plugin_row(data)
+
+
+def activate_plugin(client, plugin_id):
+    """Activate an installed plugin (shortcut for status='active')."""
+    return update_plugin(client, plugin_id, status="active")
+
+
+def deactivate_plugin(client, plugin_id):
+    """Deactivate an installed plugin (shortcut for status='inactive')."""
+    return update_plugin(client, plugin_id, status="inactive")


### PR DESCRIPTION
**v0.10.0 Phase 6, PR 1 of 5.** Closes #41.

New `wpa plugin` command group against `/wp/v2/plugins`, scoped exactly per the issue (install/delete deferred to follow-ups):

- `wpa plugin list` — `--status active|inactive|all` (default all), `--search`, all standard output modifiers. One divergence from the issue text: **no `--per-page`** — the WordPress plugins collection is not paginated (it returns every installed plugin; the controller has no pagination params), so the flag would be a no-op lie.
- `wpa plugin get <id>` — `--format json` for scripting
- `wpa plugin activate/deactivate <id>` — thin wrappers over a status update, comment-moderation style

**Identifier handling:** accepts `folder/file`, `folder/file.php` (wp-cli convention — extension stripped per PRD 4.1), or bare slugs for single-file plugins. Every segment goes through `build_endpoint` validation, so a crafted identifier can't traverse out of `/wp/v2/plugins/`.

**TDD:** 28 tests written first (RED), then module (GREEN) — identifier normalization/rejection, field validation, description flattening, status filtering, endpoint construction. **548 total**, ruff/bandit clean.

README documents the group and the `activate_plugins` capability requirement; `bootstrap-site.sh` gains the issue's idempotent smoke section (list → deactivate → activate → confirm, defaulting to Akismet, overridable via `SMOKE_PLUGIN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia