### PR TITLE
feat: wpa option get/update/list + wpa sidebar list

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,37 @@ wpa plugin deactivate akismet/akismet --site mysite
 
 Installing, updating, and deleting plugins are not supported yet — install/delete are planned (see issue #41's follow-ups); updating to a newer version is a REST API limitation, so use wp-admin or wp-cli for that.
 
+### Manage site settings
+
+Requires an account with the `manage_options` capability (administrator).
+
+```bash
+# List all registered settings
+wpa option list --site mysite
+wpa option list --site mysite --format json
+
+# Get a single value (bare output for scripting; --format json for typed)
+wpa option get title --site mysite
+wpa option get posts_per_page --site mysite --format json
+
+# Update a setting. Values are JSON-parsed when possible, so numbers and
+# booleans round-trip typed; anything else is treated as a string.
+wpa option update title "My Renamed Site" --site mysite
+wpa option update posts_per_page 20 --site mysite
+```
+
+Unlike `wp option`, this cannot touch arbitrary `wp_options` rows — the REST API only exposes options registered with `show_in_rest=true` (core settings like `title`, `description`, `timezone`, `posts_per_page`, plus whatever plugins register). Unknown names fail with the list of available settings.
+
+### List sidebars
+
+```bash
+# List registered sidebars (classic themes; block themes report none)
+wpa sidebar list --site mysite
+wpa sidebar list --site mysite --format json --fields id,name,status
+```
+
+Requires `edit_theme_options` capability. Read-only.
+
 ### Manage taxonomy terms (categories, tags, custom)
 
 ```bash

--- a/tests/test_option.py
+++ b/tests/test_option.py
@@ -1,0 +1,126 @@
+"""Tests for wpa.option — registered-settings management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.option import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    _parse_value,
+    get_setting,
+    list_settings,
+    update_setting,
+    validate_fields,
+)
+
+SAMPLE_SETTINGS = {
+    "title": "My Site",
+    "description": "Just another WordPress site",
+    "timezone": "Europe/London",
+    "posts_per_page": 10,
+    "use_smilies": True,
+    "site_icon": None,
+}
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.get.return_value = dict(SAMPLE_SETTINGS)
+    return client
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("name,value") == ["name", "value"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestParseValue:
+    def test_integer(self):
+        assert _parse_value("20") == 20
+
+    def test_boolean(self):
+        assert _parse_value("true") is True
+
+    def test_null(self):
+        assert _parse_value("null") is None
+
+    def test_quoted_string_stays_string(self):
+        assert _parse_value('"20"') == "20"
+
+    def test_plain_string_falls_back(self):
+        assert _parse_value("Europe/London") == "Europe/London"
+
+
+class TestListSettings:
+    def test_rows_sorted_by_name(self, mock_client):
+        rows = list_settings(mock_client)
+        names = [r["name"] for r in rows]
+        assert names == sorted(names)
+        mock_client.get.assert_called_once_with("settings", params=None)
+
+    def test_row_shape(self, mock_client):
+        rows = list_settings(mock_client)
+        by_name = {r["name"]: r["value"] for r in rows}
+        assert by_name["title"] == "My Site"
+        assert by_name["posts_per_page"] == 10
+
+    def test_non_dict_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = ["unexpected"]
+        assert list_settings(mock_client) == []
+
+
+class TestGetSetting:
+    def test_known_setting_returned(self, mock_client):
+        assert get_setting(mock_client, "title") == "My Site"
+
+    def test_none_value_returned(self, mock_client):
+        assert get_setting(mock_client, "site_icon") is None
+
+    def test_unknown_setting_raises_with_hint(self, mock_client):
+        with pytest.raises(ValueError, match="show_in_rest"):
+            get_setting(mock_client, "secret_option")
+
+    def test_invalid_name_shape_raises(self, mock_client):
+        with pytest.raises(ValueError, match="setting"):
+            get_setting(mock_client, "../bad")
+        mock_client.get.assert_not_called()
+
+
+class TestUpdateSetting:
+    def test_posts_parsed_value(self, mock_client):
+        mock_client.post.return_value = {**SAMPLE_SETTINGS, "posts_per_page": 20}
+        result = update_setting(mock_client, "posts_per_page", "20")
+        mock_client.post.assert_called_once_with(
+            "settings", data={"posts_per_page": 20}
+        )
+        assert result == 20
+
+    def test_string_value_passes_through(self, mock_client):
+        mock_client.post.return_value = {**SAMPLE_SETTINGS, "title": "New Name"}
+        result = update_setting(mock_client, "title", "New Name")
+        mock_client.post.assert_called_once_with("settings", data={"title": "New Name"})
+        assert result == "New Name"
+
+    def test_unknown_setting_raises_without_post(self, mock_client):
+        with pytest.raises(ValueError, match="show_in_rest"):
+            update_setting(mock_client, "secret_option", "x")
+        mock_client.post.assert_not_called()
+
+    def test_invalid_name_shape_raises(self, mock_client):
+        with pytest.raises(ValueError, match="setting"):
+            update_setting(mock_client, "bad name", "x")
+        mock_client.get.assert_not_called()
+        mock_client.post.assert_not_called()

--- a/tests/test_sidebar.py
+++ b/tests/test_sidebar.py
@@ -1,0 +1,61 @@
+"""Tests for wpa.sidebar — registered sidebar listing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.sidebar import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    list_sidebars,
+    validate_fields,
+)
+
+SAMPLE_API_SIDEBAR = {
+    "id": "sidebar-1",
+    "name": "Main Sidebar",
+    "description": "Widgets in this area appear in the sidebar.",
+    "class": "widget-area",
+    "status": "active",
+    "widgets": ["block-2", "block-3"],
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("id,status") == ["id", "status"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("id,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestListSidebars:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_SIDEBAR]
+        rows = list_sidebars(mock_client)
+        assert rows[0]["id"] == "sidebar-1"
+        assert rows[0]["name"] == "Main Sidebar"
+        assert rows[0]["status"] == "active"
+        mock_client.get.assert_called_once_with("sidebars", params={"context": "edit"})
+
+    def test_missing_keys_default_empty(self, mock_client):
+        mock_client.get.return_value = [{"id": "sidebar-9"}]
+        rows = list_sidebars(mock_client)
+        assert rows[0]["name"] == ""
+
+    def test_non_list_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = {"unexpected": "shape"}
+        assert list_sidebars(mock_client) == []

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -37,6 +37,14 @@ from wpa.media import (
 from wpa.media import (
     validate_fields as validate_media_fields,
 )
+from wpa.option import (
+    get_setting,
+    list_settings,
+    update_setting,
+)
+from wpa.option import (
+    validate_fields as validate_option_fields,
+)
 from wpa.page import (
     create_page,
     delete_page,
@@ -67,6 +75,12 @@ from wpa.post import (
     validate_fields as validate_post_fields,
 )
 from wpa.publish import parse_markdown, publish_page, resolve_file_fields
+from wpa.sidebar import (
+    list_sidebars,
+)
+from wpa.sidebar import (
+    validate_fields as validate_sidebar_fields,
+)
 from wpa.term import (
     create_term,
     delete_term,
@@ -846,6 +860,72 @@ def _do_plugin_deactivate(args):  # pragma: no cover
     return _do_plugin_toggle(deactivate_plugin, "deactivated")(args)
 
 
+def _do_option_list(args):  # pragma: no cover
+    """List registered site settings."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_option_fields(args.fields)
+        rows = list_settings(client)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_option_get(args):  # pragma: no cover
+    """Get a single registered setting's value."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        value = get_setting(client, args.name)
+        if args.format == "json":
+            print(json.dumps(value, indent=2, ensure_ascii=False))
+        else:
+            print(value)
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_option_update(args):  # pragma: no cover
+    """Update a single registered setting."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        new_value = update_setting(client, args.name, args.value)
+        print(f"Setting '{args.name}' updated.")
+        print(f"  New value: {new_value!r}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_sidebar_list(args):  # pragma: no cover
+    """List registered sidebars."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_sidebar_fields(args.fields)
+        rows = list_sidebars(client)
+        if not rows and not (args.ids or args.count or args.field):
+            print(
+                "No sidebars found. Block themes register no classic "
+                "sidebars; this is expected on a block theme."
+            )
+            return 0
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
 def _do_comment_list(args):  # pragma: no cover
     """List WordPress comments."""
     try:
@@ -1620,6 +1700,57 @@ def main(argv=None):
             "plugin", help="Plugin identifier (e.g. akismet/akismet)"
         )
         action_parser.set_defaults(func=action_func)
+
+    # --- wpa option ---
+    option_parser = subparsers.add_parser(
+        "option",
+        help="Site settings commands (registered settings only; "
+        "requires manage_options capability)",
+    )
+    option_subparsers = option_parser.add_subparsers(dest="option_command")
+
+    # wpa option list
+    option_list_parser = option_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List registered settings"
+    )
+    option_list_parser.set_defaults(func=_do_option_list)
+
+    # wpa option get <name>
+    option_get_parser = option_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single setting's value"
+    )
+    option_get_parser.add_argument("name", help="Setting name (e.g. title)")
+    option_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: bare value; json for typed output)",
+    )
+    option_get_parser.set_defaults(func=_do_option_get)
+
+    # wpa option update <name> <value>
+    option_update_parser = option_subparsers.add_parser(
+        "update", parents=[shared], help="Update a single setting"
+    )
+    option_update_parser.add_argument("name", help="Setting name (e.g. title)")
+    option_update_parser.add_argument(
+        "value",
+        help="New value (JSON-parsed when possible: numbers, true/false, null)",
+    )
+    option_update_parser.set_defaults(func=_do_option_update)
+
+    # --- wpa sidebar ---
+    sidebar_parser = subparsers.add_parser(
+        "sidebar",
+        help="Sidebar commands (requires edit_theme_options capability)",
+    )
+    sidebar_subparsers = sidebar_parser.add_subparsers(dest="sidebar_command")
+
+    # wpa sidebar list
+    sidebar_list_parser = sidebar_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List registered sidebars"
+    )
+    sidebar_list_parser.set_defaults(func=_do_sidebar_list)
 
     # --- wpa comment ---
     comment_parser = subparsers.add_parser(

--- a/wpa/option.py
+++ b/wpa/option.py
@@ -1,0 +1,146 @@
+"""Site settings management via WordPress REST API.
+
+Covers `/wp/v2/settings` — a single settings object, not a collection.
+Only options registered with `show_in_rest=true` are exposed: core settings
+like `title`, `description`, `timezone`, `posts_per_page`, plus whatever
+plugins register. Unlike wp-cli's `wp option`, arbitrary `wp_options` rows
+are not reachable. Requires the `manage_options` capability.
+"""
+
+import json
+import re
+
+_SETTING_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+# The settings object is flat name→value; rows are synthesized client-side.
+OPTION_FIELDS = {
+    "name": "name",
+    "value": "value",
+}
+
+AVAILABLE_FIELDS = list(OPTION_FIELDS.keys())
+DEFAULT_FIELDS = ["name", "value"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in OPTION_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _validate_setting_name(name):
+    """Reject setting names that aren't plain identifiers."""
+    if not isinstance(name, str) or not _SETTING_NAME_RE.match(name):
+        raise ValueError(f"Invalid setting name: {name!r}")
+
+
+def _parse_value(value):
+    """Interpret a CLI value string as JSON when possible.
+
+    "20" round-trips as an integer, "true" as a boolean, "null" as None,
+    and '"20"' as the literal string "20". Anything that isn't valid JSON
+    is passed through as a plain string.
+    """
+    try:
+        return json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return value
+
+
+def _fetch_settings(client):
+    """GET the settings object, normalized to a dict."""
+    data = client.get("settings", params=None)
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _unknown_setting_error(name, settings):
+    """Build the honest-boundaries error for a name the API doesn't expose."""
+    return ValueError(
+        f"Unknown setting '{name}'. The REST API only exposes options "
+        f"registered with show_in_rest=true. Available settings: "
+        f"{', '.join(sorted(settings))}"
+    )
+
+
+def list_settings(client):
+    """Fetch all registered settings as name/value rows.
+
+    Args:
+        client: WPApiClient instance.
+
+    Returns:
+        List of {'name': ..., 'value': ...} dicts, sorted by name.
+    """
+    settings = _fetch_settings(client)
+    return [{"name": k, "value": settings[k]} for k in sorted(settings)]
+
+
+def get_setting(client, name):
+    """Get a single registered setting's value.
+
+    Args:
+        client: WPApiClient instance.
+        name: Setting name (e.g. 'title', 'posts_per_page').
+
+    Returns:
+        The setting value (may be any JSON type, including None).
+
+    Raises:
+        ValueError: If the name is malformed or not exposed by the API.
+    """
+    _validate_setting_name(name)
+    settings = _fetch_settings(client)
+    if name not in settings:
+        raise _unknown_setting_error(name, settings)
+    return settings[name]
+
+
+def update_setting(client, name, value):
+    """Update a single registered setting.
+
+    The existence check runs before the write so an unregistered name
+    fails with a clear explanation instead of WordPress's opaque 400.
+
+    Args:
+        client: WPApiClient instance.
+        name: Setting name.
+        value: New value as a string; JSON-parsed when possible so numbers
+            and booleans round-trip typed.
+
+    Returns:
+        The updated value as returned by the API.
+
+    Raises:
+        ValueError: If the name is malformed or not exposed by the API.
+    """
+    _validate_setting_name(name)
+    settings = _fetch_settings(client)
+    if name not in settings:
+        raise _unknown_setting_error(name, settings)
+
+    parsed = _parse_value(value)
+    data = client.post("settings", data={name: parsed})
+    if isinstance(data, dict) and name in data:
+        return data[name]
+    return parsed

--- a/wpa/sidebar.py
+++ b/wpa/sidebar.py
@@ -1,0 +1,69 @@
+"""Sidebar listing via WordPress REST API.
+
+Covers `/wp/v2/sidebars` (read-only). Sidebars are registered by classic
+themes; a block theme typically reports none. Requires the
+`edit_theme_options` capability.
+"""
+
+# Maps friendly field names to WordPress REST API response keys
+SIDEBAR_FIELDS = {
+    "id": "id",
+    "name": "name",
+    "description": "description",
+    "class": "class",
+    "status": "status",
+}
+
+AVAILABLE_FIELDS = list(SIDEBAR_FIELDS.keys())
+DEFAULT_FIELDS = ["id", "name", "status"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in SIDEBAR_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _extract_sidebar_row(api_sidebar):
+    """Convert a WP REST API sidebar object to a flat dict with friendly keys."""
+    return {
+        friendly: api_sidebar.get(api_key, "")
+        for friendly, api_key in SIDEBAR_FIELDS.items()
+    }
+
+
+def list_sidebars(client):
+    """Fetch registered sidebars.
+
+    The sidebars endpoint is not paginated — WordPress returns every
+    registered sidebar in one response.
+
+    Args:
+        client: WPApiClient instance.
+
+    Returns:
+        List of sidebar dicts with friendly field names.
+    """
+    data = client.get("sidebars", params={"context": "edit"})
+    if not isinstance(data, list):
+        return []
+    return [_extract_sidebar_row(s) for s in data]


### PR DESCRIPTION
**v0.10.0 Phase 6, PR 2 of 5.** Closes #60.

## `wpa option` — `/wp/v2/settings`

- `list` — one row per registered setting, sorted by name, all output modifiers
- `get <name>` — bare value for scripting, `--format json` for typed output
- `update <name> <value>` — values JSON-parsed when possible (`posts_per_page 20` round-trips as an integer, `true`/`null` as typed; `'"20"'` forces a string)

**Honest boundaries (PRD 4.2):** the settings object only exposes `show_in_rest=true` options — unlike `wp option`, arbitrary `wp_options` rows are unreachable. Both `get` and `update` check existence first and fail with that explanation plus the available-settings list, instead of WordPress's opaque 400. The pre-write check costs one extra GET; on a settings endpoint that's negligible and the error quality is worth it.

## `wpa sidebar list` — `/wp/v2/sidebars`

Read-only listing (id, name, status default columns). Block themes register no classic sidebars, so the empty case prints an explanation rather than a bare "No results".

## Tests (TDD)

27 tests written first (RED → GREEN): value parsing, name-shape rejection, unknown-name errors without a write, sorted listing, sidebar extraction/empty handling. **575 total**, ruff/bandit clean.

README documents both groups and their capability requirements (`manage_options` / `edit_theme_options`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia