### PR TITLE
feat: wpa menu — menus, items, and locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,36 @@ wpa plugin deactivate akismet/akismet --site mysite
 
 Installing, updating, and deleting plugins are not supported yet — install/delete are planned (see issue #41's follow-ups); updating to a newer version is a REST API limitation, so use wp-admin or wp-cli for that.
 
+### Manage nav menus
+
+Classic nav menus (block themes have none). Requires `edit_theme_options` capability.
+
+```bash
+# Menus
+wpa menu list --site mysite
+wpa menu get 3 --site mysite
+wpa menu create --site mysite --name "Primary" --description "Main navigation"
+wpa menu delete 3 --site mysite    # always permanent; deletes its items too
+
+# Menu items — custom links need --title and --url
+wpa menu item list --site mysite --menu 3
+wpa menu item add 3 --site mysite --title "Docs" --url "https://example.com/docs"
+
+# Menu items — object links point at existing content
+wpa menu item add 3 --site mysite --object page --object-id 12
+wpa menu item add 3 --site mysite --object category --object-id 7
+wpa menu item add 3 --site mysite --title "Blog" --object page --object-id 8 --position 2
+
+# Reorder, re-parent, rename, remove
+wpa menu item update 71 --site mysite --position 1
+wpa menu item update 71 --site mysite --parent 70
+wpa menu item delete 71 --site mysite
+
+# Where can menus go? (read-only; assignment is theme-dependent and
+# not exposed by the REST API)
+wpa menu location list --site mysite
+```
+
 ### Manage site settings
 
 Requires an account with the `manage_options` capability (administrator).

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,237 @@
+"""Tests for wpa.menu — nav menu, menu item, and menu location management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.menu import (
+    ITEM_AVAILABLE_FIELDS,
+    ITEM_DEFAULT_FIELDS,
+    LOCATION_DEFAULT_FIELDS,
+    MENU_AVAILABLE_FIELDS,
+    MENU_DEFAULT_FIELDS,
+    create_menu,
+    create_menu_item,
+    delete_menu,
+    delete_menu_item,
+    get_menu,
+    list_menu_items,
+    list_menu_locations,
+    list_menus,
+    update_menu_item,
+    validate_item_fields,
+    validate_menu_fields,
+)
+
+SAMPLE_API_MENU = {
+    "id": 3,
+    "name": "Primary",
+    "slug": "primary",
+    "description": "Main navigation",
+    "locations": ["header"],
+    "auto_add": False,
+}
+
+SAMPLE_API_ITEM = {
+    "id": 71,
+    "title": {"raw": "About us", "rendered": "About us"},
+    "status": "publish",
+    "url": "https://example.com/about",
+    "type": "post_type",
+    "object": "page",
+    "object_id": 12,
+    "parent": 0,
+    "menu_order": 2,
+    "menus": 3,
+}
+
+SAMPLE_API_LOCATIONS = {
+    "header": {"name": "header", "description": "Header menu", "menu": 3},
+    "footer": {"name": "footer", "description": "Footer menu", "menu": 0},
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_menu_defaults(self):
+        assert validate_menu_fields(None) == MENU_DEFAULT_FIELDS
+
+    def test_menu_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_menu_fields("id,bogus")
+
+    def test_item_defaults(self):
+        assert validate_item_fields(None) == ITEM_DEFAULT_FIELDS
+
+    def test_item_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_item_fields("bogus")
+
+    def test_defaults_are_available(self):
+        for f in MENU_DEFAULT_FIELDS:
+            assert f in MENU_AVAILABLE_FIELDS
+        for f in ITEM_DEFAULT_FIELDS:
+            assert f in ITEM_AVAILABLE_FIELDS
+
+
+class TestListMenus:
+    def test_list_success(self, mock_client):
+        mock_client.get_list.return_value = iter([SAMPLE_API_MENU])
+        rows = list_menus(mock_client)
+        assert rows[0]["id"] == 3
+        assert rows[0]["name"] == "Primary"
+        endpoint = mock_client.get_list.call_args[0][0]
+        params = mock_client.get_list.call_args[1]["params"]
+        assert endpoint == "menus"
+        assert params["context"] == "edit"
+
+
+class TestGetMenu:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_MENU
+        row = get_menu(mock_client, 3)
+        assert row["name"] == "Primary"
+        assert mock_client.get.call_args[0][0] == "menus/3"
+
+    def test_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="menu ID"):
+            get_menu(mock_client, 0)
+        mock_client.get.assert_not_called()
+
+
+class TestCreateMenu:
+    def test_create_success(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_MENU
+        create_menu(mock_client, "Primary", description="Main navigation")
+        mock_client.post.assert_called_once_with(
+            "menus", data={"name": "Primary", "description": "Main navigation"}
+        )
+
+    def test_empty_name_raises(self, mock_client):
+        with pytest.raises(ValueError, match="name"):
+            create_menu(mock_client, "")
+        mock_client.post.assert_not_called()
+
+
+class TestDeleteMenu:
+    def test_delete_is_always_forced(self, mock_client):
+        delete_menu(mock_client, 3)
+        mock_client.delete.assert_called_once_with("menus/3", params={"force": True})
+
+    def test_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="menu ID"):
+            delete_menu(mock_client, -1)
+
+
+class TestListMenuItems:
+    def test_list_filters_by_menu(self, mock_client):
+        mock_client.get_list.return_value = iter([SAMPLE_API_ITEM])
+        rows = list_menu_items(mock_client, menu=3)
+        assert rows[0]["id"] == 71
+        assert rows[0]["title"] == "About us"
+        params = mock_client.get_list.call_args[1]["params"]
+        assert params["menus"] == 3
+
+    def test_title_rendered_flattened(self, mock_client):
+        mock_client.get_list.return_value = iter([SAMPLE_API_ITEM])
+        rows = list_menu_items(mock_client, menu=3)
+        assert rows[0]["title"] == "About us"
+
+    def test_invalid_menu_raises(self, mock_client):
+        with pytest.raises(ValueError, match="menu ID"):
+            list_menu_items(mock_client, menu=0)
+
+
+class TestCreateMenuItem:
+    def test_custom_item_needs_title_and_url(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_ITEM
+        create_menu_item(mock_client, 3, title="Docs", url="https://example.com/docs")
+        data = mock_client.post.call_args[1]["data"]
+        assert data["menus"] == 3
+        assert data["type"] == "custom"
+        assert data["title"] == "Docs"
+        assert data["url"] == "https://example.com/docs"
+
+    def test_object_item_defaults_to_post_type(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_ITEM
+        create_menu_item(mock_client, 3, object_type="page", object_id=12)
+        data = mock_client.post.call_args[1]["data"]
+        assert data["type"] == "post_type"
+        assert data["object"] == "page"
+        assert data["object_id"] == 12
+
+    def test_taxonomy_object_maps_to_taxonomy_type(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_ITEM
+        create_menu_item(mock_client, 3, object_type="category", object_id=7)
+        data = mock_client.post.call_args[1]["data"]
+        assert data["type"] == "taxonomy"
+        assert data["object"] == "category"
+
+    def test_parent_and_position_forwarded(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_ITEM
+        create_menu_item(
+            mock_client, 3, title="Docs", url="https://x.test", parent=71, position=4
+        )
+        data = mock_client.post.call_args[1]["data"]
+        assert data["parent"] == 71
+        assert data["menu_order"] == 4
+
+    def test_url_without_title_raises(self, mock_client):
+        with pytest.raises(ValueError, match="title"):
+            create_menu_item(mock_client, 3, url="https://example.com/docs")
+        mock_client.post.assert_not_called()
+
+    def test_neither_url_nor_object_raises(self, mock_client):
+        with pytest.raises(ValueError, match="url"):
+            create_menu_item(mock_client, 3, title="Dangling")
+        mock_client.post.assert_not_called()
+
+    def test_object_id_without_object_raises(self, mock_client):
+        with pytest.raises(ValueError, match="object"):
+            create_menu_item(mock_client, 3, object_id=12)
+        mock_client.post.assert_not_called()
+
+
+class TestUpdateMenuItem:
+    def test_update_forwards_fields(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_ITEM
+        update_menu_item(mock_client, 71, title="Renamed", menu_order=1)
+        mock_client.post.assert_called_once_with(
+            "menu-items/71", data={"title": "Renamed", "menu_order": 1}
+        )
+
+    def test_no_fields_raises(self, mock_client):
+        with pytest.raises(ValueError, match="No fields"):
+            update_menu_item(mock_client, 71)
+
+    def test_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="menu item ID"):
+            update_menu_item(mock_client, 0, title="x")
+
+
+class TestDeleteMenuItem:
+    def test_delete_is_always_forced(self, mock_client):
+        delete_menu_item(mock_client, 71)
+        mock_client.delete.assert_called_once_with(
+            "menu-items/71", params={"force": True}
+        )
+
+
+class TestListMenuLocations:
+    def test_locations_dict_to_rows(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_LOCATIONS
+        rows = list_menu_locations(mock_client)
+        names = [r["name"] for r in rows]
+        assert names == sorted(names)
+        by_name = {r["name"]: r for r in rows}
+        assert by_name["header"]["menu"] == 3
+        for f in LOCATION_DEFAULT_FIELDS:
+            assert f in rows[0]
+
+    def test_non_dict_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = ["unexpected"]
+        assert list_menu_locations(mock_client) == []

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -37,6 +37,22 @@ from wpa.media import (
 from wpa.media import (
     validate_fields as validate_media_fields,
 )
+from wpa.menu import (
+    LOCATION_DEFAULT_FIELDS as MENU_LOCATION_FIELDS,
+)
+from wpa.menu import (
+    create_menu,
+    create_menu_item,
+    delete_menu,
+    delete_menu_item,
+    get_menu,
+    list_menu_items,
+    list_menu_locations,
+    list_menus,
+    update_menu_item,
+    validate_item_fields,
+    validate_menu_fields,
+)
 from wpa.option import (
     get_setting,
     list_settings,
@@ -858,6 +874,163 @@ def _do_plugin_activate(args):  # pragma: no cover
 
 def _do_plugin_deactivate(args):  # pragma: no cover
     return _do_plugin_toggle(deactivate_plugin, "deactivated")(args)
+
+
+def _do_menu_list(args):  # pragma: no cover
+    """List nav menus."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_menu_fields(args.fields)
+        rows = list_menus(client, search=args.search)
+        if not rows and not (args.ids or args.count or args.field):
+            print(
+                "No menus found. Block themes have no classic nav menus; "
+                "this is expected on a block theme."
+            )
+            return 0
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_get(args):  # pragma: no cover
+    """Get a single nav menu."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_menu(client, args.id)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_create(args):  # pragma: no cover
+    """Create a nav menu."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        result = create_menu(client, args.name, description=args.description)
+        print("Menu created successfully!")
+        print(f"  ID:   {result.get('id')}")
+        print(f"  Name: {result.get('name')}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_delete(args):  # pragma: no cover
+    """Delete a nav menu (always permanent; its items go with it)."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        delete_menu(client, args.id)
+        print(f"Menu {args.id} deleted permanently (menus cannot be trashed).")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_item_list(args):  # pragma: no cover
+    """List menu items."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_item_fields(args.fields)
+        rows = list_menu_items(client, menu=args.menu)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_item_add(args):  # pragma: no cover
+    """Add an item to a nav menu."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        result = create_menu_item(
+            client,
+            args.menu,
+            title=args.title,
+            url=args.url,
+            object_type=args.object,
+            object_id=args.object_id,
+            item_type=args.type,
+            parent=args.parent,
+            position=args.position,
+        )
+        print("Menu item added successfully!")
+        print(f"  ID:   {result.get('id')}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_item_update(args):  # pragma: no cover
+    """Update a menu item."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = {}
+        if args.title is not None:
+            fields["title"] = args.title
+        if args.url is not None:
+            fields["url"] = args.url
+        if args.parent is not None:
+            fields["parent"] = args.parent
+        if args.position is not None:
+            fields["menu_order"] = args.position
+        update_menu_item(client, args.id, **fields)
+        print(f"Menu item {args.id} updated successfully!")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_item_delete(args):  # pragma: no cover
+    """Delete a menu item (always permanent)."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        delete_menu_item(client, args.id)
+        print(f"Menu item {args.id} deleted permanently.")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_menu_location_list(args):  # pragma: no cover
+    """List registered menu locations."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        rows = list_menu_locations(client)
+        return _format_list_output(rows, MENU_LOCATION_FIELDS, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
 
 
 def _do_option_list(args):  # pragma: no cover
@@ -1700,6 +1873,122 @@ def main(argv=None):
             "plugin", help="Plugin identifier (e.g. akismet/akismet)"
         )
         action_parser.set_defaults(func=action_func)
+
+    # --- wpa menu ---
+    menu_parser = subparsers.add_parser(
+        "menu",
+        help="Nav menu commands (requires edit_theme_options capability)",
+    )
+    menu_subparsers = menu_parser.add_subparsers(dest="menu_command")
+
+    # wpa menu list
+    menu_list_parser = menu_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List nav menus"
+    )
+    menu_list_parser.add_argument("--search", help="Search menus")
+    menu_list_parser.set_defaults(func=_do_menu_list)
+
+    # wpa menu get <id>
+    menu_get_parser = menu_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single nav menu"
+    )
+    menu_get_parser.add_argument("id", type=int, help="Menu ID")
+    menu_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    menu_get_parser.set_defaults(func=_do_menu_get)
+
+    # wpa menu create
+    menu_create_parser = menu_subparsers.add_parser(
+        "create", parents=[shared], help="Create a nav menu"
+    )
+    menu_create_parser.add_argument("--name", required=True, help="Menu name")
+    menu_create_parser.add_argument("--description", help="Menu description")
+    menu_create_parser.set_defaults(func=_do_menu_create)
+
+    # wpa menu delete <id>
+    menu_delete_parser = menu_subparsers.add_parser(
+        "delete",
+        parents=[shared],
+        help="Delete a nav menu (always permanent; deletes its items too)",
+    )
+    menu_delete_parser.add_argument("id", type=int, help="Menu ID to delete")
+    menu_delete_parser.set_defaults(func=_do_menu_delete)
+
+    # wpa menu item <subcommand>
+    menu_item_parser = menu_subparsers.add_parser("item", help="Menu item commands")
+    menu_item_subparsers = menu_item_parser.add_subparsers(dest="menu_item_command")
+
+    # wpa menu item list --menu <id>
+    item_list_parser = menu_item_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List menu items"
+    )
+    item_list_parser.add_argument("--menu", type=int, help="Filter to one menu's items")
+    item_list_parser.set_defaults(func=_do_menu_item_list)
+
+    # wpa menu item add <menu-id>
+    item_add_parser = menu_item_subparsers.add_parser(
+        "add", parents=[shared], help="Add an item to a menu"
+    )
+    item_add_parser.add_argument("menu", type=int, help="Menu ID to add to")
+    item_add_parser.add_argument(
+        "--title", help="Link text (required for custom links)"
+    )
+    item_add_parser.add_argument("--url", help="Target URL (custom link items)")
+    item_add_parser.add_argument(
+        "--object",
+        help="Linked object slug (page, post, category, post_tag, ...)",
+    )
+    item_add_parser.add_argument(
+        "--object-id", type=int, help="ID of the linked object"
+    )
+    item_add_parser.add_argument(
+        "--type",
+        help="Explicit item type (custom, post_type, taxonomy); "
+        "inferred from --url/--object when omitted",
+    )
+    item_add_parser.add_argument(
+        "--parent", type=int, help="Parent item ID for nested menus"
+    )
+    item_add_parser.add_argument("--position", type=int, help="Menu order (1-based)")
+    item_add_parser.set_defaults(func=_do_menu_item_add)
+
+    # wpa menu item update <id>
+    item_update_parser = menu_item_subparsers.add_parser(
+        "update", parents=[shared], help="Update a menu item"
+    )
+    item_update_parser.add_argument("id", type=int, help="Menu item ID")
+    item_update_parser.add_argument("--title", help="New link text")
+    item_update_parser.add_argument("--url", help="New target URL")
+    item_update_parser.add_argument("--parent", type=int, help="New parent item ID")
+    item_update_parser.add_argument(
+        "--position", type=int, help="New menu order (1-based)"
+    )
+    item_update_parser.set_defaults(func=_do_menu_item_update)
+
+    # wpa menu item delete <id>
+    item_delete_parser = menu_item_subparsers.add_parser(
+        "delete", parents=[shared], help="Delete a menu item (always permanent)"
+    )
+    item_delete_parser.add_argument("id", type=int, help="Menu item ID to delete")
+    item_delete_parser.set_defaults(func=_do_menu_item_delete)
+
+    # wpa menu location list
+    menu_location_parser = menu_subparsers.add_parser(
+        "location", help="Menu location commands"
+    )
+    menu_location_subparsers = menu_location_parser.add_subparsers(
+        dest="menu_location_command"
+    )
+    location_list_parser = menu_location_subparsers.add_parser(
+        "list",
+        parents=[shared, list_p],
+        help="List registered menu locations (read-only)",
+    )
+    location_list_parser.set_defaults(func=_do_menu_location_list)
 
     # --- wpa option ---
     option_parser = subparsers.add_parser(

--- a/wpa/menu.py
+++ b/wpa/menu.py
@@ -1,0 +1,308 @@
+"""Navigation menu management via WordPress REST API.
+
+Covers `/wp/v2/menus`, `/wp/v2/menu-items`, and `/wp/v2/menu-locations`
+(classic nav menus; block themes typically have none). All three require
+the `edit_theme_options` capability.
+
+Menu items are structure, not content, so creation follows wp-cli parity
+and publishes immediately — the "default draft" convention applies to
+content creation only.
+"""
+
+from wpa.api import build_endpoint
+
+# Objects that hang off taxonomies rather than post types, for the
+# type-inference in create_menu_item. Custom taxonomies must pass an
+# explicit item_type; these two cover the built-ins.
+_TAXONOMY_OBJECTS = {"category", "post_tag"}
+
+# Maps friendly field names to WordPress REST API response keys
+MENU_FIELDS = {
+    "id": "id",
+    "name": "name",
+    "slug": "slug",
+    "description": "description",
+    "locations": "locations",
+    "auto_add": "auto_add",
+}
+
+ITEM_FIELDS = {
+    "id": "id",
+    "title": "title",
+    "status": "status",
+    "url": "url",
+    "type": "type",
+    "object": "object",
+    "object_id": "object_id",
+    "parent": "parent",
+    "menu_order": "menu_order",
+    "menus": "menus",
+}
+
+LOCATION_FIELDS = {
+    "name": "name",
+    "description": "description",
+    "menu": "menu",
+}
+
+MENU_AVAILABLE_FIELDS = list(MENU_FIELDS.keys())
+MENU_DEFAULT_FIELDS = ["id", "name", "slug", "locations"]
+
+ITEM_AVAILABLE_FIELDS = list(ITEM_FIELDS.keys())
+ITEM_DEFAULT_FIELDS = ["id", "title", "type", "url", "menu_order"]
+
+LOCATION_AVAILABLE_FIELDS = list(LOCATION_FIELDS.keys())
+LOCATION_DEFAULT_FIELDS = ["name", "description", "menu"]
+
+
+def _make_validate_fields(field_map, available):
+    def validate(fields_str, defaults):
+        if fields_str is None:
+            return defaults
+        fields = [f.strip() for f in fields_str.split(",")]
+        for field in fields:
+            if field not in field_map:
+                raise ValueError(
+                    f"Unknown field '{field}'. Available fields: {', '.join(available)}"
+                )
+        return fields
+
+    return validate
+
+
+_validate_menu = _make_validate_fields(MENU_FIELDS, MENU_AVAILABLE_FIELDS)
+_validate_item = _make_validate_fields(ITEM_FIELDS, ITEM_AVAILABLE_FIELDS)
+
+
+def validate_menu_fields(fields_str):
+    """Validate a --fields string for menu listings."""
+    return _validate_menu(fields_str, MENU_DEFAULT_FIELDS)
+
+
+def validate_item_fields(fields_str):
+    """Validate a --fields string for menu-item listings."""
+    return _validate_item(fields_str, ITEM_DEFAULT_FIELDS)
+
+
+def _validate_id(value, label):
+    """Validate an ID is a positive integer."""
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"Invalid {label}: {value}")
+
+
+def _extract_row(api_obj, field_map):
+    """Convert an API object to a flat dict, flattening rendered titles."""
+    row = {}
+    for friendly, api_key in field_map.items():
+        value = api_obj.get(api_key, "")
+        if friendly == "title" and isinstance(value, dict):
+            value = value.get("rendered") or value.get("raw", "")
+        row[friendly] = value
+    return row
+
+
+# --- Menus ---
+
+
+def list_menus(client, search=None):
+    """Fetch nav menus.
+
+    Args:
+        client: WPApiClient instance.
+        search: Optional search term.
+
+    Returns:
+        List of menu dicts with friendly field names.
+    """
+    params = {"context": "edit", "per_page": 100}
+    if search:
+        params["search"] = search
+    return [
+        _extract_row(m, MENU_FIELDS) for m in client.get_list("menus", params=params)
+    ]
+
+
+def get_menu(client, menu_id):
+    """Get a single nav menu by ID."""
+    _validate_id(menu_id, "menu ID")
+    data = client.get(build_endpoint("menus", menu_id), params={"context": "edit"})
+    return _extract_row(data, MENU_FIELDS)
+
+
+def create_menu(client, name, description=None):
+    """Create a nav menu.
+
+    Args:
+        client: WPApiClient instance.
+        name: Menu name (required, non-empty).
+        description: Optional description.
+
+    Returns:
+        Created menu dict from API response.
+    """
+    if not name:
+        raise ValueError("Menu name cannot be empty.")
+    payload = {"name": name}
+    if description is not None:
+        payload["description"] = description
+    return client.post("menus", data=payload)
+
+
+def delete_menu(client, menu_id):
+    """Delete a nav menu.
+
+    The REST API requires `force=true` — menus cannot be trashed. Items in
+    the menu are deleted with it.
+    """
+    _validate_id(menu_id, "menu ID")
+    return client.delete(build_endpoint("menus", menu_id), params={"force": True})
+
+
+# --- Menu items ---
+
+
+def list_menu_items(client, menu=None):
+    """Fetch menu items, optionally filtered to one menu.
+
+    Args:
+        client: WPApiClient instance.
+        menu: Menu ID to filter by, or None for all items.
+
+    Returns:
+        List of item dicts with friendly field names (title flattened).
+    """
+    params = {"context": "edit", "per_page": 100}
+    if menu is not None:
+        _validate_id(menu, "menu ID")
+        params["menus"] = menu
+    return [
+        _extract_row(i, ITEM_FIELDS)
+        for i in client.get_list("menu-items", params=params)
+    ]
+
+
+def create_menu_item(
+    client,
+    menu,
+    title=None,
+    url=None,
+    object_type=None,
+    object_id=None,
+    item_type=None,
+    parent=None,
+    position=None,
+):
+    """Add an item to a nav menu.
+
+    Two shapes, mirroring wp-cli:
+    - Custom link: title + url (type=custom).
+    - Object link: object_type + object_id (type inferred: post_type for
+      posts/pages/CPTs, taxonomy for category/post_tag; pass item_type to
+      override for custom taxonomies).
+
+    Args:
+        client: WPApiClient instance.
+        menu: Menu ID the item belongs to.
+        title: Link text (required for custom links; object links default
+            to the object's own title).
+        url: Target URL for custom links.
+        object_type: REST object slug (page, post, category, post_tag, ...).
+        object_id: ID of the linked object.
+        item_type: Explicit REST item type, overriding inference.
+        parent: Parent item ID for nested menus.
+        position: Menu order (1-based).
+
+    Returns:
+        Created item dict from API response.
+
+    Raises:
+        ValueError: If the argument combination is incomplete.
+    """
+    _validate_id(menu, "menu ID")
+
+    payload = {"menus": menu}
+
+    if url:
+        if not title:
+            raise ValueError("Custom link items require a title (--title).")
+        payload["type"] = item_type or "custom"
+        payload["title"] = title
+        payload["url"] = url
+    elif object_id is not None:
+        if not object_type:
+            raise ValueError("Object items require an object type (--object).")
+        _validate_id(object_id, "object ID")
+        inferred = "taxonomy" if object_type in _TAXONOMY_OBJECTS else "post_type"
+        payload["type"] = item_type or inferred
+        payload["object"] = object_type
+        payload["object_id"] = object_id
+        if title:
+            payload["title"] = title
+    else:
+        raise ValueError(
+            "Menu items need either a url (custom link) or an "
+            "object/object ID pair (--object/--object-id)."
+        )
+
+    if parent is not None:
+        _validate_id(parent, "parent item ID")
+        payload["parent"] = parent
+    if position is not None:
+        payload["menu_order"] = position
+
+    return client.post("menu-items", data=payload)
+
+
+def update_menu_item(client, item_id, **fields):
+    """Update a menu item.
+
+    Args:
+        client: WPApiClient instance.
+        item_id: Menu item ID.
+        **fields: REST fields to update (title, url, parent, menu_order, ...).
+
+    Returns:
+        Updated item dict from API response.
+
+    Raises:
+        ValueError: If no fields are provided or the ID is invalid.
+    """
+    _validate_id(item_id, "menu item ID")
+    if not fields:
+        raise ValueError(
+            "No fields to update. Specify at least one of: "
+            "--title, --url, --parent, --position"
+        )
+    return client.post(build_endpoint("menu-items", item_id), data=fields)
+
+
+def delete_menu_item(client, item_id):
+    """Delete a menu item (force-only; items cannot be trashed)."""
+    _validate_id(item_id, "menu item ID")
+    return client.delete(build_endpoint("menu-items", item_id), params={"force": True})
+
+
+# --- Menu locations ---
+
+
+def list_menu_locations(client):
+    """Fetch registered menu locations.
+
+    The REST API returns an object keyed by location slug; rows are
+    synthesized and sorted by name. Read-only — assigning a menu to a
+    location is not exposed by the REST API (theme-dependent).
+
+    Args:
+        client: WPApiClient instance.
+
+    Returns:
+        List of location dicts (name, description, menu).
+    """
+    data = client.get("menu-locations", params=None)
+    if not isinstance(data, dict):
+        return []
+    return [
+        _extract_row(data[key], LOCATION_FIELDS)
+        for key in sorted(data)
+        if isinstance(data[key], dict)
+    ]


### PR DESCRIPTION
**v0.10.0 Phase 6, PR 3 of 5.** Closes #61.

New `wpa menu` group across the three classic-menu endpoints (`edit_theme_options` required):

## Menus
`list` (with `--search`), `get`, `create --name`, `delete` — delete is force-only (the REST API cannot trash menus) and removes the menu's items with it; the CLI output says so explicitly.

## Menu items
- `item list --menu <id>` — titles flattened from the rendered/raw object
- `item add <menu>` — both wp-cli shapes: **custom links** (`--title` + `--url` → `type=custom`) and **object links** (`--object page --object-id 12` → `type=post_type`; `--object category` → `type=taxonomy`; `--type` overrides for custom taxonomies). Incomplete combinations fail with a clear error before any request.
- `item update` (`--title/--url/--parent/--position`), `item delete` (force-only)
- Items publish immediately per wp-cli parity — the default-draft convention covers content, not menu structure (rationale in the module docstring).

## Locations
`location list` — read-only; the API's slug-keyed object is synthesized into sorted rows. Assignment stays unexposed (theme-dependent, PARTIAL in the mapping matrix — honest boundaries).

Block themes: empty menu listings print an explanation instead of a bare "No results".

**TDD:** 28 tests written first (RED → GREEN): type inference, argument-combination validation, force-only deletes, title flattening, location synthesis. **603 total**, ruff/bandit clean. README documents the group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia