### PR TITLE
feat: wpa widget — list, get, update, deactivate, delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,32 @@ wpa option update posts_per_page 20 --site mysite
 
 Unlike `wp option`, this cannot touch arbitrary `wp_options` rows — the REST API only exposes options registered with `show_in_rest=true` (core settings like `title`, `description`, `timezone`, `posts_per_page`, plus whatever plugins register). Unknown names fail with the list of available settings.
 
+### Manage widgets
+
+Classic widgets (block themes manage widgets as blocks). Requires `edit_theme_options` capability.
+
+```bash
+# List widgets, optionally per sidebar
+wpa widget list --site mysite
+wpa widget list --site mysite --sidebar sidebar-1
+
+# Get a single widget
+wpa widget get recent-posts-3 --site mysite
+
+# Move a widget to another sidebar and/or update its settings
+wpa widget update recent-posts-3 --site mysite --sidebar sidebar-2
+wpa widget update recent-posts-3 --site mysite --instance-json '{"title": "Latest", "number": 3}'
+
+# Deactivate (move to the inactive sidebar; settings kept)
+wpa widget deactivate recent-posts-3 --site mysite
+
+# Delete — default parks it in the inactive sidebar; --force removes entirely
+wpa widget delete recent-posts-3 --site mysite
+wpa widget delete recent-posts-3 --site mysite --force
+```
+
+Creating widgets from the CLI is not supported — each widget type has its own instance schema, so there is no generic safe `widget add`. Configure new widgets in wp-admin, then manage them here.
+
 ### List sidebars
 
 ```bash

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,0 +1,156 @@
+"""Tests for wpa.widget — classic widget management."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.widget import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    INACTIVE_SIDEBAR,
+    _extract_widget_row,
+    deactivate_widget,
+    delete_widget,
+    get_widget,
+    list_widgets,
+    update_widget,
+    validate_fields,
+)
+
+SAMPLE_API_WIDGET = {
+    "id": "recent-posts-3",
+    "id_base": "recent-posts",
+    "sidebar": "sidebar-1",
+    "rendered": "<ul><li>Post</li></ul>",
+    "instance": {"raw": {"title": "Latest", "number": 5}},
+}
+
+SAMPLE_INACTIVE_WIDGET = {
+    "id": "calendar-2",
+    "id_base": "calendar",
+    "sidebar": "wp_inactive_widgets",
+    "rendered": "",
+    "instance": {"raw": {}},
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("id,sidebar") == ["id", "sidebar"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("id,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestExtractWidgetRow:
+    def test_status_synthesized_active(self):
+        row = _extract_widget_row(SAMPLE_API_WIDGET)
+        assert row["status"] == "active"
+        assert row["id"] == "recent-posts-3"
+        assert row["sidebar"] == "sidebar-1"
+
+    def test_status_synthesized_inactive(self):
+        row = _extract_widget_row(SAMPLE_INACTIVE_WIDGET)
+        assert row["status"] == "inactive"
+
+
+class TestListWidgets:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_WIDGET]
+        rows = list_widgets(mock_client)
+        assert rows[0]["id"] == "recent-posts-3"
+        mock_client.get.assert_called_once_with("widgets", params={"context": "edit"})
+
+    def test_sidebar_filter(self, mock_client):
+        mock_client.get.return_value = []
+        list_widgets(mock_client, sidebar="sidebar-1")
+        params = mock_client.get.call_args[1]["params"]
+        assert params["sidebar"] == "sidebar-1"
+
+    def test_non_list_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = {"unexpected": "shape"}
+        assert list_widgets(mock_client) == []
+
+
+class TestGetWidget:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_WIDGET
+        row = get_widget(mock_client, "recent-posts-3")
+        assert row["id_base"] == "recent-posts"
+        assert mock_client.get.call_args[0][0] == "widgets/recent-posts-3"
+
+    def test_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="widget"):
+            get_widget(mock_client, "../evil")
+        mock_client.get.assert_not_called()
+
+
+class TestUpdateWidget:
+    def test_move_to_sidebar(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_WIDGET
+        update_widget(mock_client, "recent-posts-3", sidebar="sidebar-2")
+        mock_client.post.assert_called_once_with(
+            "widgets/recent-posts-3", data={"sidebar": "sidebar-2"}
+        )
+
+    def test_instance_json_parsed(self, mock_client):
+        mock_client.post.return_value = SAMPLE_API_WIDGET
+        update_widget(
+            mock_client, "recent-posts-3", instance_json='{"title": "X", "number": 3}'
+        )
+        data = mock_client.post.call_args[1]["data"]
+        assert data["instance"] == {"raw": {"title": "X", "number": 3}}
+
+    def test_invalid_instance_json_raises(self, mock_client):
+        with pytest.raises(ValueError, match="JSON"):
+            update_widget(mock_client, "recent-posts-3", instance_json="{nope")
+        mock_client.post.assert_not_called()
+
+    def test_non_object_instance_json_raises(self, mock_client):
+        with pytest.raises(ValueError, match="object"):
+            update_widget(mock_client, "recent-posts-3", instance_json='["a"]')
+        mock_client.post.assert_not_called()
+
+    def test_no_fields_raises(self, mock_client):
+        with pytest.raises(ValueError, match="No fields"):
+            update_widget(mock_client, "recent-posts-3")
+        mock_client.post.assert_not_called()
+
+
+class TestDeactivateWidget:
+    def test_moves_to_inactive_sidebar(self, mock_client):
+        mock_client.post.return_value = SAMPLE_INACTIVE_WIDGET
+        deactivate_widget(mock_client, "recent-posts-3")
+        mock_client.post.assert_called_once_with(
+            "widgets/recent-posts-3", data={"sidebar": INACTIVE_SIDEBAR}
+        )
+
+
+class TestDeleteWidget:
+    def test_delete_forced(self, mock_client):
+        delete_widget(mock_client, "recent-posts-3", force=True)
+        mock_client.delete.assert_called_once_with(
+            "widgets/recent-posts-3", params={"force": True}
+        )
+
+    def test_delete_default_moves_to_inactive(self, mock_client):
+        delete_widget(mock_client, "recent-posts-3")
+        mock_client.delete.assert_called_once_with("widgets/recent-posts-3", params={})
+
+    def test_invalid_id_raises(self, mock_client):
+        with pytest.raises(ValueError, match="widget"):
+            delete_widget(mock_client, "a/b")
+        mock_client.delete.assert_not_called()

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -122,6 +122,16 @@ from wpa.user import (
 from wpa.user import (
     validate_fields as validate_user_fields,
 )
+from wpa.widget import (
+    deactivate_widget,
+    delete_widget,
+    get_widget,
+    list_widgets,
+    update_widget,
+)
+from wpa.widget import (
+    validate_fields as validate_widget_fields,
+)
 
 
 def _format_api_error(e):
@@ -1099,6 +1109,94 @@ def _do_sidebar_list(args):  # pragma: no cover
         return _handle_api_error(e)
 
 
+def _do_widget_list(args):  # pragma: no cover
+    """List classic widgets."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_widget_fields(args.fields)
+        rows = list_widgets(client, sidebar=args.sidebar)
+        if not rows and not (args.ids or args.count or args.field):
+            print(
+                "No widgets found. Block themes manage widgets as blocks; "
+                "this is expected on a block theme."
+            )
+            return 0
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_widget_get(args):  # pragma: no cover
+    """Get a single widget."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_widget(client, args.id)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_widget_update(args):  # pragma: no cover
+    """Move a widget and/or update its instance settings."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        update_widget(
+            client, args.id, sidebar=args.sidebar, instance_json=args.instance_json
+        )
+        print(f"Widget {args.id} updated successfully!")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_widget_deactivate(args):  # pragma: no cover
+    """Move a widget to the inactive sidebar."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        deactivate_widget(client, args.id)
+        print(f"Widget {args.id} moved to the inactive sidebar (settings kept).")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_widget_delete(args):  # pragma: no cover
+    """Delete a widget (inactive-sidebar by default, --force removes)."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        delete_widget(client, args.id, force=args.force)
+        if args.force:
+            print(f"Widget {args.id} removed entirely.")
+        else:
+            print(
+                f"Widget {args.id} moved to the inactive sidebar "
+                "(use --force to remove entirely)."
+            )
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
 def _do_comment_list(args):  # pragma: no cover
     """List WordPress comments."""
     try:
@@ -2040,6 +2138,70 @@ def main(argv=None):
         "list", parents=[shared, list_p], help="List registered sidebars"
     )
     sidebar_list_parser.set_defaults(func=_do_sidebar_list)
+
+    # --- wpa widget ---
+    widget_parser = subparsers.add_parser(
+        "widget",
+        help="Classic widget commands (requires edit_theme_options capability)",
+    )
+    widget_subparsers = widget_parser.add_subparsers(dest="widget_command")
+
+    # wpa widget list
+    widget_list_parser = widget_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List widgets"
+    )
+    widget_list_parser.add_argument(
+        "--sidebar", help="Filter to one sidebar (e.g. sidebar-1)"
+    )
+    widget_list_parser.set_defaults(func=_do_widget_list)
+
+    # wpa widget get <id>
+    widget_get_parser = widget_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single widget"
+    )
+    widget_get_parser.add_argument("id", help="Widget ID (e.g. recent-posts-3)")
+    widget_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    widget_get_parser.set_defaults(func=_do_widget_get)
+
+    # wpa widget update <id>
+    widget_update_parser = widget_subparsers.add_parser(
+        "update", parents=[shared], help="Move a widget or update its settings"
+    )
+    widget_update_parser.add_argument("id", help="Widget ID")
+    widget_update_parser.add_argument(
+        "--sidebar", help="Target sidebar ID (moves the widget)"
+    )
+    widget_update_parser.add_argument(
+        "--instance-json",
+        help='Instance settings as a JSON object (e.g. \'{"title": "X"}\')',
+    )
+    widget_update_parser.set_defaults(func=_do_widget_update)
+
+    # wpa widget deactivate <id>
+    widget_deactivate_parser = widget_subparsers.add_parser(
+        "deactivate",
+        parents=[shared],
+        help="Move a widget to the inactive sidebar (settings kept)",
+    )
+    widget_deactivate_parser.add_argument("id", help="Widget ID")
+    widget_deactivate_parser.set_defaults(func=_do_widget_deactivate)
+
+    # wpa widget delete <id>
+    widget_delete_parser = widget_subparsers.add_parser(
+        "delete", parents=[shared], help="Delete a widget"
+    )
+    widget_delete_parser.add_argument("id", help="Widget ID")
+    widget_delete_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Remove entirely (default moves to the inactive sidebar)",
+    )
+    widget_delete_parser.set_defaults(func=_do_widget_delete)
 
     # --- wpa comment ---
     comment_parser = subparsers.add_parser(

--- a/wpa/widget.py
+++ b/wpa/widget.py
@@ -1,0 +1,176 @@
+"""Classic widget management via WordPress REST API.
+
+Covers `/wp/v2/widgets` — list, get, update (move/reconfigure), delete,
+and a wp-cli-style `deactivate` (move to the inactive sidebar). Block
+themes manage widgets as blocks, so these endpoints typically return
+nothing there. Requires the `edit_theme_options` capability.
+
+Widget *creation* is deliberately not implemented: each widget type has
+its own instance schema (discoverable only via `/wp/v2/widget-types`),
+which makes a generic `widget add` an exercise in guessing serialized
+PHP shapes. Descoped per #62; revisit if a concrete use case appears.
+"""
+
+import json
+
+from wpa.api import build_endpoint
+
+# WordPress's holding pen for widgets removed from live sidebars.
+INACTIVE_SIDEBAR = "wp_inactive_widgets"
+
+# Maps friendly field names to WordPress REST API response keys.
+# `status` is synthesized from the sidebar (the API has no status field).
+WIDGET_FIELDS = {
+    "id": "id",
+    "id_base": "id_base",
+    "sidebar": "sidebar",
+    "status": None,
+}
+
+AVAILABLE_FIELDS = list(WIDGET_FIELDS.keys())
+DEFAULT_FIELDS = ["id", "id_base", "sidebar", "status"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in WIDGET_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _widget_endpoint(widget_id):
+    """Build the validated endpoint for a single widget.
+
+    Widget IDs are slugs like 'recent-posts-3'; build_endpoint's segment
+    validation rejects anything that could escape the path.
+    """
+    try:
+        return build_endpoint("widgets", widget_id)
+    except ValueError:
+        raise ValueError(f"Invalid widget ID: {widget_id!r}") from None
+
+
+def _extract_widget_row(api_widget):
+    """Convert a WP REST API widget object to a flat dict with friendly keys."""
+    sidebar = api_widget.get("sidebar", "")
+    row = {}
+    for friendly, api_key in WIDGET_FIELDS.items():
+        if friendly == "status":
+            row[friendly] = "inactive" if sidebar == INACTIVE_SIDEBAR else "active"
+        else:
+            row[friendly] = api_widget.get(api_key, "")
+    return row
+
+
+def list_widgets(client, sidebar=None):
+    """Fetch widgets, optionally filtered to one sidebar.
+
+    The widgets endpoint is not paginated — WordPress returns every widget
+    in one response.
+
+    Args:
+        client: WPApiClient instance.
+        sidebar: Sidebar ID to filter by (e.g. 'sidebar-1'), or None.
+
+    Returns:
+        List of widget dicts with friendly field names.
+    """
+    params = {"context": "edit"}
+    if sidebar:
+        params["sidebar"] = sidebar
+    data = client.get("widgets", params=params)
+    if not isinstance(data, list):
+        return []
+    return [_extract_widget_row(w) for w in data]
+
+
+def get_widget(client, widget_id):
+    """Get a single widget by ID (e.g. 'recent-posts-3')."""
+    endpoint = _widget_endpoint(widget_id)
+    data = client.get(endpoint, params={"context": "edit"})
+    return _extract_widget_row(data)
+
+
+def update_widget(client, widget_id, sidebar=None, instance_json=None):
+    """Move a widget between sidebars and/or update its instance settings.
+
+    Args:
+        client: WPApiClient instance.
+        widget_id: Widget ID.
+        sidebar: Target sidebar ID (moves the widget), or None.
+        instance_json: JSON object string of instance settings, or None.
+
+    Returns:
+        Updated widget dict from API response.
+
+    Raises:
+        ValueError: If neither field is given, or instance_json is not a
+            valid JSON object.
+    """
+    endpoint = _widget_endpoint(widget_id)
+
+    payload = {}
+    if sidebar:
+        payload["sidebar"] = sidebar
+    if instance_json is not None:
+        try:
+            instance = json.loads(instance_json)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"--instance-json is not valid JSON: {e}") from None
+        if not isinstance(instance, dict):
+            raise ValueError("--instance-json must be a JSON object.")
+        payload["instance"] = {"raw": instance}
+
+    if not payload:
+        raise ValueError(
+            "No fields to update. Specify --sidebar and/or --instance-json."
+        )
+
+    return client.post(endpoint, data=payload)
+
+
+def deactivate_widget(client, widget_id):
+    """Move a widget to the inactive sidebar (wp-cli parity).
+
+    The widget keeps its settings and can be moved back with
+    `update_widget(..., sidebar=...)`.
+    """
+    endpoint = _widget_endpoint(widget_id)
+    return client.post(endpoint, data={"sidebar": INACTIVE_SIDEBAR})
+
+
+def delete_widget(client, widget_id, force=False):
+    """Delete a widget.
+
+    Without force, WordPress moves the widget to the inactive sidebar
+    (settings preserved). With force, the widget is removed entirely.
+
+    Args:
+        client: WPApiClient instance.
+        widget_id: Widget ID.
+        force: Remove entirely instead of moving to inactive.
+
+    Returns:
+        Deletion response dict from API.
+    """
+    endpoint = _widget_endpoint(widget_id)
+    params = {"force": True} if force else {}
+    return client.delete(endpoint, params=params)


### PR DESCRIPTION
**v0.10.0 Phase 6, PR 4 of 5.** Closes #62.

New `wpa widget` group against `/wp/v2/widgets` (`edit_theme_options` required):

- **`list`** (`--sidebar` filter) / **`get`** — `status` is synthesized client-side from the sidebar (`wp_inactive_widgets` → inactive); the REST widget object has no status field
- **`update`** — move (`--sidebar`) and/or reconfigure (`--instance-json`, validated as a JSON object, wrapped in the API's `{raw: ...}` envelope)
- **`deactivate`** — wp-cli parity: parks the widget in the inactive sidebar with settings kept
- **`delete`** — REST semantics surfaced honestly: default moves to the inactive sidebar, `--force` removes entirely, and the CLI states which happened

**`widget add` descoped**, exercising #62's feasibility clause: each widget type carries its own instance schema (discoverable only via `/wp/v2/widget-types`), so a generic create command would be schema guesswork. Rationale in the module docstring and README; can be revisited with a concrete use case.

**TDD:** 20 tests written first (RED → GREEN): status synthesis, sidebar filtering, instance-JSON validation (bad JSON and non-object rejected before any request), force-vs-default delete semantics, ID validation via `build_endpoint`. **623 total**, ruff/bandit clean. README documents the group. Block-theme empty listings print an explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia