### PR TITLE
docs(release): v0.10.0 — PRD v1.4, release notes, version bump

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ CI runs on ubuntu/macos/windows across Python 3.10, 3.11, 3.12, 3.13, plus a wee
 
 ## Architecture
 
-**Entry point**: `wpa/cli.py` — argparse-based CLI with subcommands (`publish`, `post list/get/create/update/delete`, `page list/get/create/update/delete`, `site add/list`, `user list/get/create/update/delete/set-role`, `media list/get/import/delete`, `comment list/get/create/update/delete/approve/unapprove/spam/unspam/trash/count`, `term list/get/create/update/delete`, plus `category` and `tag` aliases).
+**Entry point**: `wpa/cli.py` — argparse-based CLI with subcommands (`publish`, `post list/get/create/update/delete`, `page list/get/create/update/delete`, `site add/list`, `user list/get/create/update/delete/set-role`, `media list/get/import/delete`, `comment list/get/create/update/delete/approve/unapprove/spam/unspam/trash/count`, `term list/get/create/update/delete` plus `category`/`tag` aliases, `plugin list/get/activate/deactivate`, `menu list/get/create/delete` with `item` and `location` sub-groups, `widget list/get/update/deactivate/delete`, `option list/get/update`, `sidebar list`).
 
 **Modules**:
 - `cli.py` — Command parsing, dispatches to other modules
@@ -46,11 +46,16 @@ CI runs on ubuntu/macos/windows across Python 3.10, 3.11, 3.12, 3.13, plus a wee
 - `media.py` — Media CRUD operations against `/wp-json/wp/v2/media`. Uses `WPApiClient` for all requests. Supports `list` (with `--media-type`/`--mime-type` filters), `get`, `import` (multipart upload from a local file with optional title/alt-text/caption/description/post), and `delete` (trash-aware, `--force` to permanently delete)
 - `comment.py` — Comment CRUD and moderation against `/wp-json/wp/v2/comments`. Supports `list` (filter by post, status, parent, author email, search), `get`, `create`, `update`, `delete` (trash-aware, `--force` to permanently delete), plus moderation shortcuts `approve`, `unapprove`, `spam`, `unspam`, `trash`, and `count` (per-status totals via the `X-WP-Total` header)
 - `term.py` — Taxonomy term CRUD against `/wp-json/wp/v2/{categories,tags,<custom>}`. One module handles built-in taxonomies (`category` → `categories`, `post_tag` → `tags`) and custom taxonomies (passed through by slug). The CLI exposes `wpa term --taxonomy <slug>` plus thin `wpa category` / `wpa tag` aliases that pre-set the taxonomy. Term `delete` is always permanent (the REST API does not support trashing terms).
+- `plugin.py` — Plugin management against `/wp-json/wp/v2/plugins`. `list` (`--status`/`--search`; the collection is not paginated), `get`, `activate`, `deactivate`. Identifiers accept `folder/file`, `folder/file.php`, or bare slugs; segments validated via `build_endpoint`. Install/delete deliberately unimplemented (#41 follow-ups)
+- `menu.py` — Nav menu management against `/wp-json/wp/v2/{menus,menu-items,menu-locations}` (classic menus). Menu CRUD (delete force-only), item CRUD (`add` infers `custom`/`post_type`/`taxonomy` type from flags), read-only location listing. Menu items publish immediately (structure, not content)
+- `widget.py` — Classic widget management against `/wp-json/wp/v2/widgets`. `list`/`get` (status synthesized from sidebar; `get` flattens instance settings), `update` (move and/or `--instance-json`), `deactivate` (move to `wp_inactive_widgets`), `delete` (default parks inactive, `--force` removes). No `widget add` — per-type instance schemas
+- `option.py` — Registered-settings management against `/wp-json/wp/v2/settings` (single object, not a collection). `list`/`get`/`update` with JSON-typed value parsing; existence-checked before writes so unknown names get the `show_in_rest` explanation
+- `sidebar.py` — Read-only sidebar listing against `/wp-json/wp/v2/sidebars`
 - `formatter.py` — Shared output formatting (table, json, csv, tsv) with column selection via `--fields`, plus `--ids`, `--count`, `--field` output modifiers
 
 **Global flags**: `--debug` (HTTP request/response details) available on all commands. `--site` selects a named site config.
 
-**Tests**: All in `tests/` (520 tests), use `unittest.mock` to mock HTTP requests. No live WordPress connection needed.
+**Tests**: All in `tests/` (626 tests), use `unittest.mock` to mock HTTP requests. No live WordPress connection needed.
 
 ## Key Conventions
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,93 @@
 # Release Notes
 
+## v0.10.0 — Phase 6: Plugins, Menus, Widgets, Settings (2026-08-09)
+
+Five new command groups covering PRD Phase 6 — the site-structure tier of
+the REST API. All privilege checks stay server-side per WPA's design:
+these commands require `activate_plugins`, `edit_theme_options`, or
+`manage_options` capabilities (administrator, typically).
+
+On PyPI as [wpa 0.10.0](https://pypi.org/project/wpa/0.10.0/) —
+`pip install --upgrade wpa`.
+
+### `wpa plugin` (#41)
+
+```bash
+wpa plugin list --status active          # not paginated — WP returns all
+wpa plugin get akismet/akismet           # folder/file, .php suffix accepted
+wpa plugin activate wordfence/wordfence
+wpa plugin deactivate wordfence/wordfence
+```
+
+Identifiers are validated per segment (traversal-proof); the wp-cli
+`folder/file.php` convention is accepted and normalized. Install and
+delete are deliberately deferred (distinct error surfaces — #41's
+follow-ups); version updates are a REST API impossibility.
+
+### `wpa menu` (#61)
+
+Menus, items, and locations for classic themes:
+
+```bash
+wpa menu create --name "Primary"
+wpa menu item add 3 --title "Docs" --url https://example.com/docs
+wpa menu item add 3 --object page --object-id 12   # type inferred
+wpa menu item update 71 --position 1
+wpa menu location list                             # read-only
+```
+
+Item types are inferred (`custom` from `--url`; `post_type` or
+`taxonomy` from `--object`) with `--type` as the override. Menu and item
+deletes are force-only — the REST API cannot trash them — and the CLI
+says so. Location *assignment* is theme-dependent and not exposed.
+
+### `wpa widget` (#62)
+
+```bash
+wpa widget list --sidebar sidebar-1
+wpa widget get recent-posts-3            # includes instance settings
+wpa widget update recent-posts-3 --sidebar sidebar-2
+wpa widget update recent-posts-3 --instance-json '{"title": "Latest"}'
+wpa widget deactivate recent-posts-3     # inactive sidebar, settings kept
+wpa widget delete recent-posts-3 --force
+```
+
+Status is synthesized from the sidebar (the API has no status field).
+`widget add` is deliberately unsupported: every widget type has its own
+instance schema, so a generic create would be guesswork.
+
+### `wpa option` + `wpa sidebar` (#60)
+
+```bash
+wpa option list
+wpa option get posts_per_page            # bare value for scripting
+wpa option update posts_per_page 20     # JSON-typed: arrives as an integer
+wpa sidebar list
+```
+
+Honest boundaries: only options registered with `show_in_rest=true` are
+reachable (unlike `wp option`, which reads the whole `wp_options` table).
+Unknown names fail with that explanation and the list of available
+settings — checked *before* the write, not after WordPress's opaque 400.
+
+### Block themes
+
+All three theme-structure groups (menus, widgets, sidebars) are
+classic-theme constructs. Empty listings on block themes print an
+explanation instead of a bare "No results".
+
+### Quality
+
+- **Tests:** 626 total, +106 from v0.9.0 — every module written
+  test-first per the CLAUDE.md workflow.
+- The release-diff security audit found no injection surface (all
+  dynamic endpoints route through `build_endpoint`; `--instance-json`
+  is parsed, never evaluated) and one completeness gap, fixed in-release:
+  `widget get` now shows instance settings, without which
+  `update --instance-json` would have been blind.
+- ruff, bandit, and pip-audit clean; the bootstrap smoke script gained
+  an idempotent plugin round-trip section.
+
 ## v0.9.0 — Housekeeping: Python 3.10 Floor + Author Attribution (2026-08-09)
 
 A hardening and infrastructure release. The minor-version bump signals one

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -54,6 +54,10 @@ class TestValidateFields:
         for f in DEFAULT_FIELDS:
             assert f in AVAILABLE_FIELDS
 
+    def test_instance_available_but_not_default(self):
+        assert "instance" in AVAILABLE_FIELDS
+        assert "instance" not in DEFAULT_FIELDS
+
 
 class TestExtractWidgetRow:
     def test_status_synthesized_active(self):
@@ -96,6 +100,18 @@ class TestGetWidget:
         with pytest.raises(ValueError, match="widget"):
             get_widget(mock_client, "../evil")
         mock_client.get.assert_not_called()
+
+    def test_instance_settings_flattened(self, mock_client):
+        # Release-audit follow-up: update --instance-json is unusable if
+        # get cannot show the current instance settings.
+        mock_client.get.return_value = SAMPLE_API_WIDGET
+        row = get_widget(mock_client, "recent-posts-3")
+        assert row["instance"] == {"title": "Latest", "number": 5}
+
+    def test_instance_missing_defaults_empty(self, mock_client):
+        mock_client.get.return_value = {"id": "x-1", "sidebar": "sidebar-1"}
+        row = get_widget(mock_client, "x-1")
+        assert row["instance"] == ""
 
 
 class TestUpdateWidget:

--- a/wpa-prd.md
+++ b/wpa-prd.md
@@ -1,10 +1,10 @@
 # WPA — Product Requirements Document
 
 **Product:** WPA (WordPress Automation)
-**Version:** PRD v1.3
+**Version:** PRD v1.4
 **Date:** 2026-08-09
 **Author:** Neil Johnson, Cadent Creative
-**Current release:** v0.9.0
+**Current release:** v0.10.0
 **Repository:** [github.com/cadentdev/wpa](https://github.com/cadentdev/wpa)
 **PyPI:** [pypi.org/project/wpa](https://pypi.org/project/wpa/)
 **License:** MIT
@@ -158,10 +158,11 @@ wpa/
 ├── comment.py      # Comment subcommand handlers
 ├── media.py        # Media subcommand handlers
 ├── term.py         # Term/taxonomy subcommand handlers
-├── plugin.py       # Plugin subcommand handlers      (planned, Phase 6)
-├── menu.py         # Menu subcommand handlers        (planned, Phase 6)
-├── widget.py       # Widget subcommand handlers      (planned, Phase 6)
-├── option.py       # Settings/option subcommand handlers (planned, Phase 6)
+├── plugin.py       # Plugin subcommand handlers
+├── menu.py         # Menu subcommand handlers
+├── widget.py       # Widget subcommand handlers
+├── option.py       # Settings/option subcommand handlers
+├── sidebar.py      # Sidebar subcommand handlers
 ├── formatter.py    # Output formatting (table, JSON, CSV, TSV)
 └── __init__.py     # Package version (single source, read by pyproject)
 ```
@@ -232,7 +233,7 @@ These are the quality bars every release meets (folded in from the retired devel
 
 ## 6. Command structure
 
-### 6.1 Implemented commands (v0.9.0)
+### 6.1 Implemented commands (v0.10.0)
 
 **Content publishing**
 
@@ -301,6 +302,45 @@ These are the quality bars every release meets (folded in from the retired devel
 | `wpa category …` | Alias for `wpa term --taxonomy category` |
 | `wpa tag …` | Alias for `wpa term --taxonomy post_tag` |
 
+**Plugins** (Tier 3, shipped v0.10.0)
+
+| Command | Description |
+|---|---|
+| `wpa plugin list` | List installed plugins with `--status active/inactive/all`, `--search`. Not paginated — the REST plugins collection returns everything |
+| `wpa plugin get <id>` | Get a single plugin (`folder/file`, `folder/file.php`, or bare slug identifiers) |
+| `wpa plugin activate/deactivate <id>` | Toggle activation status. Requires `activate_plugins` capability. Install/delete deferred (see #41 follow-ups) |
+
+**Nav menus** (Tier 3, shipped v0.10.0; requires `edit_theme_options`)
+
+| Command | Description |
+|---|---|
+| `wpa menu list/get/create/delete` | Menu CRUD. Delete is always permanent and removes the menu's items |
+| `wpa menu item list/add/update/delete` | Item management. `add` supports custom links (`--title --url`) and object links (`--object --object-id`, type inferred) |
+| `wpa menu location list` | Read-only location listing; assignment is theme-dependent and not exposed by the REST API |
+
+**Widgets** (Tier 3, shipped v0.10.0; requires `edit_theme_options`)
+
+| Command | Description |
+|---|---|
+| `wpa widget list/get` | Classic widgets with synthesized active/inactive status; `get` includes instance settings |
+| `wpa widget update <id>` | Move between sidebars (`--sidebar`) and/or replace settings (`--instance-json`) |
+| `wpa widget deactivate <id>` | Move to the inactive sidebar, settings kept |
+| `wpa widget delete <id>` | Default parks in the inactive sidebar; `--force` removes entirely. `widget add` deliberately unsupported (per-type instance schemas) |
+
+**Site settings** (Tier 3, shipped v0.10.0; requires `manage_options`)
+
+| Command | Description |
+|---|---|
+| `wpa option list` | All registered (`show_in_rest`) settings as name/value rows |
+| `wpa option get <name>` | Single value; bare output for scripting, `--format json` for typed |
+| `wpa option update <name> <value>` | Values JSON-parsed when possible so numbers/booleans round-trip typed |
+
+**Sidebars** (Tier 3, shipped v0.10.0)
+
+| Command | Description |
+|---|---|
+| `wpa sidebar list` | Read-only listing of registered sidebars |
+
 **Site configuration**
 
 | Command | Description |
@@ -317,17 +357,7 @@ These are the quality bars every release meets (folded in from the retired devel
 
 ### 6.2 Planned command groups
 
-Based on the REST API mapping matrix, the following command groups are implementable and prioritized by value. (Tiers 1 and 2 — posts, pages, users, media, comments, and terms — shipped in v0.6.0–v0.8.0 and are documented in §6.1.)
-
-**Tier 3 — Site configuration and structure**
-
-| Command Group | Key Subcommands | REST API Endpoint |
-|---|---|---|
-| `wpa plugin` | `list`, `get`, `install`, `activate`, `deactivate`, `delete` | `/wp/v2/plugins` |
-| `wpa menu` | `list`, `create`, `delete`, plus `item` subgroup | `/wp/v2/menus`, `/wp/v2/menu-items` |
-| `wpa widget` | `list`, `add`, `update`, `delete`, `deactivate` | `/wp/v2/widgets` |
-| `wpa option` | `get`, `update`, `list` (registered settings only) | `/wp/v2/settings` |
-| `wpa sidebar` | `list` | `/wp/v2/sidebars` |
+Based on the REST API mapping matrix, the following command groups are implementable and prioritized by value. (Tiers 1–3 — posts, pages, users, media, comments, terms, plugins, menus, widgets, settings, and sidebars — shipped in v0.6.0–v0.10.0 and are documented in §6.1. Plugin `install`/`delete` remain open as #41 follow-ups.)
 
 **Tier 4 — Introspection and discovery**
 
@@ -437,15 +467,17 @@ Shipped in v0.8.0 (2026-04-15). See `RELEASE-NOTES.md` for full notes including 
 | Env-configurable safety caps (`WPA_MAX_RESPONSE_BYTES`, `WPA_MAX_TOTAL_PAGES`) | Shipped v0.9.0 |
 | Docs current: PRD refresh, README positioning, recommendations doc folded in and archived | Shipped v0.9.0 |
 
-### Phase 6: Plugins, menus, and widgets (v0.10.0)
+### Phase 6: Plugins, menus, and widgets (v0.10.0) — COMPLETE
 
-| Deliverable | Details |
+**Shipped:** v0.10.0, 2026-08-09.
+
+| Deliverable | Status |
 |---|---|
-| `wpa plugin` subcommands | `list`, `get`, `install`, `activate`, `deactivate`, `delete`, `search` |
-| `wpa menu` subcommands | `list`, `create`, `delete` plus `item` sub-group |
-| `wpa widget` subcommands | `list`, `add`, `update`, `delete`, `deactivate` |
-| `wpa sidebar list` | List registered sidebars |
-| `wpa option` subcommands | `get`, `update`, `list` for registered settings |
+| `wpa plugin list/get/activate/deactivate` | Shipped v0.10.0 (`install`/`delete` deferred per #41; `search` descoped — it queries WordPress.org, not the site) |
+| `wpa menu list/get/create/delete` + `item` sub-group + `location list` | Shipped v0.10.0 |
+| `wpa widget list/get/update/delete/deactivate` | Shipped v0.10.0 (`add` descoped: per-type instance schemas make a generic create guesswork) |
+| `wpa sidebar list` | Shipped v0.10.0 |
+| `wpa option get/update/list` | Shipped v0.10.0 |
 
 ### Phase 7: Introspection and discovery (v0.11.0)
 

--- a/wpa/__init__.py
+++ b/wpa/__init__.py
@@ -1,3 +1,3 @@
 """WordPress Automation — manage posts, pages, and users via the REST API."""
 
-__version__ = "0.9.0"
+__version__ = "0.10.0"

--- a/wpa/widget.py
+++ b/wpa/widget.py
@@ -19,12 +19,15 @@ from wpa.api import build_endpoint
 INACTIVE_SIDEBAR = "wp_inactive_widgets"
 
 # Maps friendly field names to WordPress REST API response keys.
-# `status` is synthesized from the sidebar (the API has no status field).
+# `status` is synthesized from the sidebar (the API has no status field);
+# `instance` is flattened to its raw settings dict so `widget get` shows
+# the current config that `update --instance-json` would replace.
 WIDGET_FIELDS = {
     "id": "id",
     "id_base": "id_base",
     "sidebar": "sidebar",
     "status": None,
+    "instance": "instance",
 }
 
 AVAILABLE_FIELDS = list(WIDGET_FIELDS.keys())
@@ -75,8 +78,11 @@ def _extract_widget_row(api_widget):
     for friendly, api_key in WIDGET_FIELDS.items():
         if friendly == "status":
             row[friendly] = "inactive" if sidebar == INACTIVE_SIDEBAR else "active"
-        else:
-            row[friendly] = api_widget.get(api_key, "")
+            continue
+        value = api_widget.get(api_key, "")
+        if friendly == "instance" and isinstance(value, dict):
+            value = value.get("raw", "")
+        row[friendly] = value
     return row
 
 


### PR DESCRIPTION
**v0.10.0 Phase 6, PR 5 of 5 — the release PR.**

Merging this completes the release; I'll then tag `v0.10.0`, create the GitHub Release, and trusted publishing ships to PyPI.

## Release-audit follow-up (steps 7–8)

The full v0.9.0→main diff review found **no security issues** — all dynamic endpoints route through `build_endpoint` (traversal tests cover `../`, multi-segment abuse), the option name is body-only, `--instance-json` is parsed not evaluated, and privilege checks stay server-side. It found **one completeness gap, fixed here test-first**: `widget get` omitted instance settings, making `update --instance-json` blind. `get` now flattens `instance.raw`; `list` defaults stay compact (available via `--fields`). 3 new tests → **626 total**, 98% coverage held.

## Docs (step 9)

- **PRD → v1.4**: §6.1 gains all five Phase 6 command tables; §6.2 planned tiers trimmed to 4–5; §5.1 package tree current; Phase 6 marked COMPLETE with the descope record (plugin install/delete deferred per #41, `widget add` and `plugin search` descoped with rationale)
- **CLAUDE.md**: command list + module descriptions for the five new groups, test count
- **RELEASE-NOTES.md**: v0.10.0 section (command tour, honest-boundaries notes, block-theme behavior, audit summary)

## Version (step 10)

Bumped to **0.10.0** in `wpa/__init__.py` only; verified `python -m build` produces `wpa-0.10.0.tar.gz`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia