### PR TITLE
feat: taxonomy and post-type introspection (#69, #70)

### DIFF
--- a/tests/test_post_type.py
+++ b/tests/test_post_type.py
@@ -1,0 +1,102 @@
+"""Tests for wpa.post_type — registered post type introspection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.post_type import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    get_post_type,
+    list_post_types,
+    validate_fields,
+)
+
+SAMPLE_API_POST_TYPE = {
+    "name": "Posts",
+    "slug": "post",
+    "description": "",
+    "hierarchical": False,
+    "rest_base": "posts",
+    "taxonomies": ["category", "post_tag"],
+}
+
+SAMPLE_API_POST_TYPES = {
+    "post": SAMPLE_API_POST_TYPE,
+    "page": {
+        "name": "Pages",
+        "slug": "page",
+        "description": "",
+        "hierarchical": True,
+        "rest_base": "pages",
+        "taxonomies": [],
+    },
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("slug,taxonomies") == ["slug", "taxonomies"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("slug,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestListPostTypes:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_POST_TYPES
+        rows = list_post_types(mock_client)
+        assert [r["slug"] for r in rows] == ["page", "post"]
+        assert rows[1]["name"] == "Posts"
+        mock_client.get.assert_called_once_with("types", params={"context": "edit"})
+
+    def test_taxonomies_list_joined(self, mock_client):
+        mock_client.get.return_value = {"post": SAMPLE_API_POST_TYPE}
+        rows = list_post_types(mock_client)
+        assert rows[0]["taxonomies"] == "category, post_tag"
+
+    def test_missing_keys_default_empty(self, mock_client):
+        mock_client.get.return_value = {"post": {"slug": "post"}}
+        rows = list_post_types(mock_client)
+        assert rows[0]["description"] == ""
+
+    def test_non_dict_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_POST_TYPE]
+        assert list_post_types(mock_client) == []
+
+    def test_non_dict_values_skipped(self, mock_client):
+        mock_client.get.return_value = {
+            "post": SAMPLE_API_POST_TYPE,
+            "weird": 42,
+        }
+        rows = list_post_types(mock_client)
+        assert len(rows) == 1
+
+
+class TestGetPostType:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_POST_TYPE
+        row = get_post_type(mock_client, "post")
+        assert row["slug"] == "post"
+        assert row["hierarchical"] is False
+        mock_client.get.assert_called_once_with(
+            "types/post", params={"context": "edit"}
+        )
+
+    def test_invalid_slug_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Invalid post type slug"):
+            get_post_type(mock_client, "a/b")
+        mock_client.get.assert_not_called()

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,115 @@
+"""Tests for wpa.taxonomy — registered taxonomy introspection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.taxonomy import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    get_taxonomy,
+    list_taxonomies,
+    validate_fields,
+)
+
+SAMPLE_API_TAXONOMY = {
+    "name": "Categories",
+    "slug": "category",
+    "description": "",
+    "hierarchical": True,
+    "rest_base": "categories",
+    "types": ["post"],
+}
+
+SAMPLE_API_TAXONOMIES = {
+    "category": SAMPLE_API_TAXONOMY,
+    "post_tag": {
+        "name": "Tags",
+        "slug": "post_tag",
+        "description": "",
+        "hierarchical": False,
+        "rest_base": "tags",
+        "types": ["post"],
+    },
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("slug,types") == ["slug", "types"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("slug,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestListTaxonomies:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_TAXONOMIES
+        rows = list_taxonomies(mock_client)
+        assert [r["slug"] for r in rows] == ["category", "post_tag"]
+        assert rows[0]["name"] == "Categories"
+        assert rows[0]["hierarchical"] is True
+        mock_client.get.assert_called_once_with(
+            "taxonomies", params={"context": "edit"}
+        )
+
+    def test_rows_sorted_by_slug_key(self, mock_client):
+        mock_client.get.return_value = {
+            "zeta": {"slug": "zeta", "name": "Z"},
+            "alpha": {"slug": "alpha", "name": "A"},
+        }
+        rows = list_taxonomies(mock_client)
+        assert [r["slug"] for r in rows] == ["alpha", "zeta"]
+
+    def test_types_list_joined(self, mock_client):
+        mock_client.get.return_value = {
+            "category": {**SAMPLE_API_TAXONOMY, "types": ["post", "page"]}
+        }
+        rows = list_taxonomies(mock_client)
+        assert rows[0]["types"] == "post, page"
+
+    def test_missing_keys_default_empty(self, mock_client):
+        mock_client.get.return_value = {"category": {"slug": "category"}}
+        rows = list_taxonomies(mock_client)
+        assert rows[0]["name"] == ""
+
+    def test_non_dict_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_TAXONOMY]
+        assert list_taxonomies(mock_client) == []
+
+    def test_non_dict_values_skipped(self, mock_client):
+        mock_client.get.return_value = {
+            "category": SAMPLE_API_TAXONOMY,
+            "weird": "not-an-object",
+        }
+        rows = list_taxonomies(mock_client)
+        assert len(rows) == 1
+
+
+class TestGetTaxonomy:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_TAXONOMY
+        row = get_taxonomy(mock_client, "category")
+        assert row["slug"] == "category"
+        assert row["types"] == "post"
+        mock_client.get.assert_called_once_with(
+            "taxonomies/category", params={"context": "edit"}
+        )
+
+    def test_invalid_slug_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Invalid taxonomy slug"):
+            get_taxonomy(mock_client, "../users")
+        mock_client.get.assert_not_called()

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -90,12 +90,26 @@ from wpa.post import (
 from wpa.post import (
     validate_fields as validate_post_fields,
 )
+from wpa.post_type import (
+    get_post_type,
+    list_post_types,
+)
+from wpa.post_type import (
+    validate_fields as validate_post_type_fields,
+)
 from wpa.publish import parse_markdown, publish_page, resolve_file_fields
 from wpa.sidebar import (
     list_sidebars,
 )
 from wpa.sidebar import (
     validate_fields as validate_sidebar_fields,
+)
+from wpa.taxonomy import (
+    get_taxonomy,
+    list_taxonomies,
+)
+from wpa.taxonomy import (
+    validate_fields as validate_taxonomy_fields,
 )
 from wpa.term import (
     create_term,
@@ -823,6 +837,70 @@ def _do_media_delete(args):  # pragma: no cover
 
 
 # --- Comment handlers ---
+
+
+def _do_taxonomy_list(args):  # pragma: no cover
+    """List registered taxonomies."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_taxonomy_fields(args.fields)
+        rows = list_taxonomies(client)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_taxonomy_get(args):  # pragma: no cover
+    """Get a single registered taxonomy."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_taxonomy(client, args.taxonomy)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_post_type_list(args):  # pragma: no cover
+    """List registered post types."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_post_type_fields(args.fields)
+        rows = list_post_types(client)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_post_type_get(args):  # pragma: no cover
+    """Get a single registered post type."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_post_type(client, args.post_type)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
 
 
 def _do_plugin_list(args):  # pragma: no cover
@@ -1924,6 +2002,58 @@ def main(argv=None):
     )
     media_delete_parser.set_defaults(func=_do_media_delete)
 
+    # --- wpa taxonomy ---
+    taxonomy_parser = subparsers.add_parser(
+        "taxonomy",
+        help="Inspect registered taxonomies (read-only)",
+    )
+    taxonomy_subparsers = taxonomy_parser.add_subparsers(dest="taxonomy_command")
+
+    # wpa taxonomy list
+    taxonomy_list_parser = taxonomy_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List registered taxonomies"
+    )
+    taxonomy_list_parser.set_defaults(func=_do_taxonomy_list)
+
+    # wpa taxonomy get <slug>
+    taxonomy_get_parser = taxonomy_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single registered taxonomy"
+    )
+    taxonomy_get_parser.add_argument("taxonomy", help="Taxonomy slug (e.g. category)")
+    taxonomy_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    taxonomy_get_parser.set_defaults(func=_do_taxonomy_get)
+
+    # --- wpa post-type ---
+    post_type_parser = subparsers.add_parser(
+        "post-type",
+        help="Inspect registered post types (read-only)",
+    )
+    post_type_subparsers = post_type_parser.add_subparsers(dest="post_type_command")
+
+    # wpa post-type list
+    post_type_list_parser = post_type_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List registered post types"
+    )
+    post_type_list_parser.set_defaults(func=_do_post_type_list)
+
+    # wpa post-type get <slug>
+    post_type_get_parser = post_type_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single registered post type"
+    )
+    post_type_get_parser.add_argument("post_type", help="Post type slug (e.g. post)")
+    post_type_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    post_type_get_parser.set_defaults(func=_do_post_type_get)
+
     # --- wpa plugin ---
     plugin_parser = subparsers.add_parser(
         "plugin",
@@ -2473,6 +2603,18 @@ def main(argv=None):
         args, "tag_command", None
     ):  # pragma: no cover
         tag_parser.print_help()
+        return 1
+
+    if args.command == "taxonomy" and not getattr(
+        args, "taxonomy_command", None
+    ):  # pragma: no cover
+        taxonomy_parser.print_help()
+        return 1
+
+    if args.command == "post-type" and not getattr(
+        args, "post_type_command", None
+    ):  # pragma: no cover
+        post_type_parser.print_help()
         return 1
 
     return args.func(args)

--- a/wpa/post_type.py
+++ b/wpa/post_type.py
@@ -1,0 +1,91 @@
+"""Registered post type introspection via WordPress REST API.
+
+Covers `/wp/v2/types` — read-only. The list endpoint returns a
+slug-keyed object (not an array) and is not paginated, like
+menu-locations. The command name is `post-type`, following wp-cli.
+"""
+
+from wpa.api import build_endpoint
+
+# Maps friendly field names to WordPress REST API response keys.
+# `taxonomies` (the taxonomies attached to a post type) arrives as a
+# list and is joined for display.
+POST_TYPE_FIELDS = {
+    "slug": "slug",
+    "name": "name",
+    "description": "description",
+    "hierarchical": "hierarchical",
+    "rest_base": "rest_base",
+    "taxonomies": "taxonomies",
+}
+
+AVAILABLE_FIELDS = list(POST_TYPE_FIELDS.keys())
+DEFAULT_FIELDS = ["slug", "name", "hierarchical", "rest_base"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in POST_TYPE_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _extract_post_type_row(api_post_type):
+    """Convert a WP REST API type object to a flat dict with friendly keys."""
+    row = {}
+    for friendly, api_key in POST_TYPE_FIELDS.items():
+        value = api_post_type.get(api_key, "")
+        if isinstance(value, list):
+            value = ", ".join(str(v) for v in value)
+        row[friendly] = value
+    return row
+
+
+def list_post_types(client):
+    """Fetch registered post types.
+
+    The REST API returns an object keyed by post type slug; rows are
+    synthesized and sorted by slug.
+
+    Args:
+        client: WPApiClient instance.
+
+    Returns:
+        List of post type dicts with friendly field names.
+    """
+    data = client.get("types", params={"context": "edit"})
+    if not isinstance(data, dict):
+        return []
+    return [
+        _extract_post_type_row(data[key])
+        for key in sorted(data)
+        if isinstance(data[key], dict)
+    ]
+
+
+def get_post_type(client, slug):
+    """Get a single registered post type by slug (e.g. 'post')."""
+    try:
+        endpoint = build_endpoint("types", slug)
+    except ValueError:
+        raise ValueError(f"Invalid post type slug: {slug!r}") from None
+    data = client.get(endpoint, params={"context": "edit"})
+    return _extract_post_type_row(data)

--- a/wpa/taxonomy.py
+++ b/wpa/taxonomy.py
@@ -1,0 +1,92 @@
+"""Registered taxonomy introspection via WordPress REST API.
+
+Covers `/wp/v2/taxonomies` — read-only. The list endpoint returns a
+slug-keyed object (not an array) and is not paginated, like
+menu-locations. Complements `wpa term`: `taxonomy list` shows which
+slugs `term --taxonomy` accepts on a given site.
+"""
+
+from wpa.api import build_endpoint
+
+# Maps friendly field names to WordPress REST API response keys.
+# `types` (the object types a taxonomy attaches to) arrives as a list
+# and is joined for display.
+TAXONOMY_FIELDS = {
+    "slug": "slug",
+    "name": "name",
+    "description": "description",
+    "hierarchical": "hierarchical",
+    "rest_base": "rest_base",
+    "types": "types",
+}
+
+AVAILABLE_FIELDS = list(TAXONOMY_FIELDS.keys())
+DEFAULT_FIELDS = ["slug", "name", "hierarchical", "rest_base"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in TAXONOMY_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _extract_taxonomy_row(api_taxonomy):
+    """Convert a WP REST API taxonomy object to a flat dict with friendly keys."""
+    row = {}
+    for friendly, api_key in TAXONOMY_FIELDS.items():
+        value = api_taxonomy.get(api_key, "")
+        if isinstance(value, list):
+            value = ", ".join(str(v) for v in value)
+        row[friendly] = value
+    return row
+
+
+def list_taxonomies(client):
+    """Fetch registered taxonomies.
+
+    The REST API returns an object keyed by taxonomy slug; rows are
+    synthesized and sorted by slug.
+
+    Args:
+        client: WPApiClient instance.
+
+    Returns:
+        List of taxonomy dicts with friendly field names.
+    """
+    data = client.get("taxonomies", params={"context": "edit"})
+    if not isinstance(data, dict):
+        return []
+    return [
+        _extract_taxonomy_row(data[key])
+        for key in sorted(data)
+        if isinstance(data[key], dict)
+    ]
+
+
+def get_taxonomy(client, slug):
+    """Get a single registered taxonomy by slug (e.g. 'category')."""
+    try:
+        endpoint = build_endpoint("taxonomies", slug)
+    except ValueError:
+        raise ValueError(f"Invalid taxonomy slug: {slug!r}") from None
+    data = client.get(endpoint, params={"context": "edit"})
+    return _extract_taxonomy_row(data)


### PR DESCRIPTION
PR 1 of 4 for the v0.11.0 milestone (Phase 7: introspection).

- `wpa taxonomy list/get` — /wp/v2/taxonomies (closes #69)
- `wpa post-type list/get` — /wp/v2/types (closes #70)

Both endpoints return slug-keyed objects (not arrays, not paginated); rows are synthesized and sorted by slug via the menu-locations pattern. List-valued fields (`types`, `taxonomies`) are comma-joined for display. `get` slugs validated through `build_endpoint`.

TDD: 23 new tests written first (649 total, 98% coverage). Both new groups include no-subcommand help guards; the equivalent pre-existing crash in the Phase 6 groups is filed as #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia