### PR TITLE
feat: block and theme introspection (#71, #73)

### DIFF
--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,0 +1,103 @@
+"""Tests for wpa.block — registered block type introspection."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.block import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    get_block,
+    list_blocks,
+    validate_fields,
+)
+
+SAMPLE_API_BLOCK = {
+    "name": "core/paragraph",
+    "title": "Paragraph",
+    "category": "text",
+    "description": "Start with the basic building block of all narrative.",
+    "keywords": ["text"],
+    "api_version": 3,
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("name,keywords") == ["name", "keywords"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("name,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestListBlocks:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_BLOCK]
+        rows = list_blocks(mock_client)
+        assert rows[0]["name"] == "core/paragraph"
+        assert rows[0]["title"] == "Paragraph"
+        assert rows[0]["category"] == "text"
+        mock_client.get.assert_called_once_with(
+            "block-types", params={"context": "edit"}
+        )
+
+    def test_namespace_filter(self, mock_client):
+        mock_client.get.return_value = []
+        list_blocks(mock_client, namespace="core")
+        mock_client.get.assert_called_once_with(
+            "block-types", params={"context": "edit", "namespace": "core"}
+        )
+
+    def test_keywords_list_joined(self, mock_client):
+        mock_client.get.return_value = [
+            {**SAMPLE_API_BLOCK, "keywords": ["text", "prose"]}
+        ]
+        rows = list_blocks(mock_client)
+        assert rows[0]["keywords"] == "text, prose"
+
+    def test_missing_keys_default_empty(self, mock_client):
+        mock_client.get.return_value = [{"name": "core/quote"}]
+        rows = list_blocks(mock_client)
+        assert rows[0]["title"] == ""
+
+    def test_non_list_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = {"unexpected": "shape"}
+        assert list_blocks(mock_client) == []
+
+
+class TestGetBlock:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_BLOCK
+        row = get_block(mock_client, "core/paragraph")
+        assert row["name"] == "core/paragraph"
+        mock_client.get.assert_called_once_with(
+            "block-types/core/paragraph", params={"context": "edit"}
+        )
+
+    def test_unnamespaced_name_raises(self, mock_client):
+        with pytest.raises(ValueError, match="namespace/name"):
+            get_block(mock_client, "paragraph")
+        mock_client.get.assert_not_called()
+
+    def test_too_many_segments_raises(self, mock_client):
+        with pytest.raises(ValueError, match="namespace/name"):
+            get_block(mock_client, "a/b/c")
+        mock_client.get.assert_not_called()
+
+    def test_invalid_segment_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Invalid block name"):
+            get_block(mock_client, "core/../users")
+        mock_client.get.assert_not_called()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,116 @@
+"""Tests for wpa.theme — read-only theme information."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.theme import (
+    AVAILABLE_FIELDS,
+    DEFAULT_FIELDS,
+    THEME_STATUSES,
+    get_theme,
+    list_themes,
+    validate_fields,
+)
+
+SAMPLE_API_THEME = {
+    "stylesheet": "twentytwentyfive",
+    "template": "twentytwentyfive",
+    "name": {"raw": "Twenty Twenty-Five", "rendered": "Twenty Twenty-Five"},
+    "status": "active",
+    "version": "1.1",
+    "author": {"raw": "the WordPress team", "rendered": "the WordPress team"},
+    "description": {"raw": "Twenty Twenty-Five emphasizes simplicity.", "rendered": ""},
+    "requires_wp": "6.7",
+    "requires_php": "7.2",
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_none_returns_defaults(self):
+        assert validate_fields(None) == DEFAULT_FIELDS
+
+    def test_valid_fields_parsed(self):
+        assert validate_fields("stylesheet,template") == ["stylesheet", "template"]
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_fields("stylesheet,bogus")
+
+    def test_defaults_are_available(self):
+        for f in DEFAULT_FIELDS:
+            assert f in AVAILABLE_FIELDS
+
+
+class TestListThemes:
+    def test_list_success(self, mock_client):
+        mock_client.get.return_value = [SAMPLE_API_THEME]
+        rows = list_themes(mock_client)
+        assert rows[0]["stylesheet"] == "twentytwentyfive"
+        assert rows[0]["name"] == "Twenty Twenty-Five"
+        assert rows[0]["status"] == "active"
+        mock_client.get.assert_called_once_with("themes", params={"context": "edit"})
+
+    def test_status_filter(self, mock_client):
+        mock_client.get.return_value = []
+        list_themes(mock_client, status="active")
+        mock_client.get.assert_called_once_with(
+            "themes", params={"context": "edit", "status": "active"}
+        )
+
+    def test_invalid_status_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Invalid status"):
+            list_themes(mock_client, status="broken")
+        mock_client.get.assert_not_called()
+
+    def test_statuses_constant(self):
+        assert THEME_STATUSES == ("active", "inactive")
+
+    def test_rendered_preferred_over_raw(self, mock_client):
+        mock_client.get.return_value = [
+            {**SAMPLE_API_THEME, "author": {"raw": "raw author", "rendered": ""}}
+        ]
+        rows = list_themes(mock_client)
+        # rendered is empty -> falls back to raw
+        assert rows[0]["author"] == "raw author"
+
+    def test_missing_keys_default_empty(self, mock_client):
+        mock_client.get.return_value = [{"stylesheet": "bare"}]
+        rows = list_themes(mock_client)
+        assert rows[0]["name"] == ""
+
+    def test_non_list_response_returns_empty(self, mock_client):
+        mock_client.get.return_value = {"unexpected": "shape"}
+        assert list_themes(mock_client) == []
+
+
+class TestGetTheme:
+    def test_get_success(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_THEME
+        row = get_theme(mock_client, "twentytwentyfive")
+        assert row["stylesheet"] == "twentytwentyfive"
+        mock_client.get.assert_called_once_with(
+            "themes/twentytwentyfive", params={"context": "edit"}
+        )
+
+    def test_subdirectory_stylesheet(self, mock_client):
+        mock_client.get.return_value = SAMPLE_API_THEME
+        get_theme(mock_client, "parent/child")
+        mock_client.get.assert_called_once_with(
+            "themes/parent/child", params={"context": "edit"}
+        )
+
+    def test_invalid_stylesheet_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Invalid theme stylesheet"):
+            get_theme(mock_client, "../plugins")
+        mock_client.get.assert_not_called()
+
+    def test_empty_stylesheet_raises(self, mock_client):
+        with pytest.raises(ValueError, match="Invalid theme stylesheet"):
+            get_theme(mock_client, "")
+        mock_client.get.assert_not_called()

--- a/wpa/block.py
+++ b/wpa/block.py
@@ -1,0 +1,103 @@
+"""Registered block type introspection via WordPress REST API.
+
+Covers `/wp/v2/block-types` — read-only. Sites register hundreds of
+blocks, so default fields stay narrow; use `--namespace` to scope the
+listing. Block names are namespaced (`core/paragraph`), so `get` takes
+exactly two path segments. Requires the `edit_posts` capability.
+"""
+
+from wpa.api import build_endpoint
+
+# Maps friendly field names to WordPress REST API response keys.
+# `keywords` arrives as a list and is joined for display.
+BLOCK_FIELDS = {
+    "name": "name",
+    "title": "title",
+    "category": "category",
+    "description": "description",
+    "keywords": "keywords",
+    "api_version": "api_version",
+}
+
+AVAILABLE_FIELDS = list(BLOCK_FIELDS.keys())
+DEFAULT_FIELDS = ["name", "title", "category"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in BLOCK_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _extract_block_row(api_block):
+    """Convert a WP REST API block type object to a flat dict with friendly keys."""
+    row = {}
+    for friendly, api_key in BLOCK_FIELDS.items():
+        value = api_block.get(api_key, "")
+        if isinstance(value, list):
+            value = ", ".join(str(v) for v in value)
+        row[friendly] = value
+    return row
+
+
+def _block_endpoint(name):
+    """Build the validated endpoint for a single block type.
+
+    Block names are namespaced (`core/paragraph`); each segment is
+    validated via build_endpoint so nothing can escape the path.
+    """
+    parts = name.split("/") if name else []
+    if len(parts) != 2 or not all(parts):
+        raise ValueError(
+            f"Invalid block name: {name!r} "
+            "(expected namespace/name, e.g. core/paragraph)"
+        )
+    try:
+        return build_endpoint("block-types", *parts)
+    except ValueError:
+        raise ValueError(f"Invalid block name: {name!r}") from None
+
+
+def list_blocks(client, namespace=None):
+    """Fetch registered block types, optionally scoped to one namespace.
+
+    Args:
+        client: WPApiClient instance.
+        namespace: Block namespace to filter by (e.g. 'core'), or None.
+
+    Returns:
+        List of block type dicts with friendly field names.
+    """
+    params = {"context": "edit"}
+    if namespace:
+        params["namespace"] = namespace
+    data = client.get("block-types", params=params)
+    if not isinstance(data, list):
+        return []
+    return [_extract_block_row(b) for b in data]
+
+
+def get_block(client, name):
+    """Get a single registered block type by namespaced name."""
+    endpoint = _block_endpoint(name)
+    data = client.get(endpoint, params={"context": "edit"})
+    return _extract_block_row(data)

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -6,6 +6,13 @@ import sys
 
 from wpa import __version__
 from wpa.api import WPApiClient
+from wpa.block import (
+    get_block,
+    list_blocks,
+)
+from wpa.block import (
+    validate_fields as validate_block_fields,
+)
 from wpa.comment import (
     COUNT_STATUSES as COMMENT_COUNT_STATUSES,
 )
@@ -120,6 +127,14 @@ from wpa.term import (
 )
 from wpa.term import (
     validate_fields as validate_term_fields,
+)
+from wpa.theme import (
+    THEME_STATUSES,
+    get_theme,
+    list_themes,
+)
+from wpa.theme import (
+    validate_fields as validate_theme_fields,
 )
 from wpa.user import (
     DEFAULT_FIELDS as USER_DEFAULT_FIELDS,
@@ -837,6 +852,71 @@ def _do_media_delete(args):  # pragma: no cover
 
 
 # --- Comment handlers ---
+
+
+def _do_block_list(args):  # pragma: no cover
+    """List registered block types."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_block_fields(args.fields)
+        rows = list_blocks(client, namespace=args.namespace)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_block_get(args):  # pragma: no cover
+    """Get a single registered block type."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_block(client, args.block)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_theme_list(args):  # pragma: no cover
+    """List installed themes."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        fields = validate_theme_fields(args.fields)
+        status = None if args.status == "all" else args.status
+        rows = list_themes(client, status=status)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
+
+
+def _do_theme_get(args):  # pragma: no cover
+    """Get a single installed theme."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        row = get_theme(client, args.stylesheet)
+        if args.format == "json":
+            print(json.dumps(row, indent=2, ensure_ascii=False))
+        else:
+            for key, value in row.items():
+                print(f"{key}: {value}")
+        return 0
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
 
 
 def _do_taxonomy_list(args):  # pragma: no cover
@@ -2054,6 +2134,71 @@ def main(argv=None):
     )
     post_type_get_parser.set_defaults(func=_do_post_type_get)
 
+    # --- wpa block ---
+    block_parser = subparsers.add_parser(
+        "block",
+        help="Inspect registered block types (read-only)",
+    )
+    block_subparsers = block_parser.add_subparsers(dest="block_command")
+
+    # wpa block list
+    block_list_parser = block_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List registered block types"
+    )
+    block_list_parser.add_argument(
+        "--namespace", help="Filter by block namespace (e.g. core)"
+    )
+    block_list_parser.set_defaults(func=_do_block_list)
+
+    # wpa block get <name>
+    block_get_parser = block_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single registered block type"
+    )
+    block_get_parser.add_argument(
+        "block", help="Namespaced block name (e.g. core/paragraph)"
+    )
+    block_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    block_get_parser.set_defaults(func=_do_block_get)
+
+    # --- wpa theme ---
+    theme_parser = subparsers.add_parser(
+        "theme",
+        help="Read-only theme information (listing all requires switch_themes)",
+    )
+    theme_subparsers = theme_parser.add_subparsers(dest="theme_command")
+
+    # wpa theme list
+    theme_list_parser = theme_subparsers.add_parser(
+        "list", parents=[shared, list_p], help="List installed themes"
+    )
+    theme_list_parser.add_argument(
+        "--status",
+        choices=[*THEME_STATUSES, "all"],
+        default="all",
+        help="Filter by status (default: all)",
+    )
+    theme_list_parser.set_defaults(func=_do_theme_list)
+
+    # wpa theme get <stylesheet>
+    theme_get_parser = theme_subparsers.add_parser(
+        "get", parents=[shared], help="Get a single installed theme"
+    )
+    theme_get_parser.add_argument(
+        "stylesheet", help="Theme stylesheet (e.g. twentytwentyfive)"
+    )
+    theme_get_parser.add_argument(
+        "--format",
+        default="table",
+        choices=["table", "json"],
+        help="Output format (default: table)",
+    )
+    theme_get_parser.set_defaults(func=_do_theme_get)
+
     # --- wpa plugin ---
     plugin_parser = subparsers.add_parser(
         "plugin",
@@ -2615,6 +2760,18 @@ def main(argv=None):
         args, "post_type_command", None
     ):  # pragma: no cover
         post_type_parser.print_help()
+        return 1
+
+    if args.command == "block" and not getattr(
+        args, "block_command", None
+    ):  # pragma: no cover
+        block_parser.print_help()
+        return 1
+
+    if args.command == "theme" and not getattr(
+        args, "theme_command", None
+    ):  # pragma: no cover
+        theme_parser.print_help()
         return 1
 
     return args.func(args)

--- a/wpa/theme.py
+++ b/wpa/theme.py
@@ -1,0 +1,119 @@
+"""Read-only theme information via WordPress REST API.
+
+Covers `/wp/v2/themes` — list and get only. The REST API does not
+expose theme activation, installation, or deletion; those stay out of
+scope. Listing every theme requires the `switch_themes` capability;
+`status=active` works with lower capabilities.
+"""
+
+from wpa.api import build_endpoint
+
+THEME_STATUSES = ("active", "inactive")
+
+# Maps friendly field names to WordPress REST API response keys.
+# name/author/description arrive as {raw, rendered} objects and are
+# flattened (rendered preferred, raw as fallback).
+THEME_FIELDS = {
+    "stylesheet": "stylesheet",
+    "name": "name",
+    "status": "status",
+    "version": "version",
+    "author": "author",
+    "template": "template",
+    "description": "description",
+    "requires_wp": "requires_wp",
+    "requires_php": "requires_php",
+}
+
+AVAILABLE_FIELDS = list(THEME_FIELDS.keys())
+DEFAULT_FIELDS = ["stylesheet", "name", "status", "version"]
+
+
+def validate_fields(fields_str):
+    """Parse and validate a comma-separated fields string.
+
+    Args:
+        fields_str: Comma-separated field names, or None for defaults.
+
+    Returns:
+        List of validated field names.
+
+    Raises:
+        ValueError: If any field name is not in AVAILABLE_FIELDS.
+    """
+    if fields_str is None:
+        return DEFAULT_FIELDS
+
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in THEME_FIELDS:
+            raise ValueError(
+                f"Unknown field '{field}'. "
+                f"Available fields: {', '.join(AVAILABLE_FIELDS)}"
+            )
+    return fields
+
+
+def _extract_theme_row(api_theme):
+    """Convert a WP REST API theme object to a flat dict with friendly keys."""
+    row = {}
+    for friendly, api_key in THEME_FIELDS.items():
+        value = api_theme.get(api_key, "")
+        if isinstance(value, dict):
+            value = value.get("rendered") or value.get("raw", "")
+        row[friendly] = value
+    return row
+
+
+def _theme_endpoint(stylesheet):
+    """Build the validated endpoint for a single theme.
+
+    Stylesheets are usually a bare slug, but child themes on some hosts
+    live in subdirectories (`parent/child`); each segment is validated
+    via build_endpoint.
+    """
+    parts = stylesheet.split("/") if stylesheet else []
+    if not parts or not all(parts):
+        raise ValueError(f"Invalid theme stylesheet: {stylesheet!r}")
+    try:
+        return build_endpoint("themes", *parts)
+    except ValueError:
+        raise ValueError(f"Invalid theme stylesheet: {stylesheet!r}") from None
+
+
+def list_themes(client, status=None):
+    """Fetch installed themes, optionally filtered by status.
+
+    The themes collection is not paginated. Listing all themes requires
+    `switch_themes`; a lower-capability user can still request
+    `status=active`.
+
+    Args:
+        client: WPApiClient instance.
+        status: 'active', 'inactive', or None for all.
+
+    Returns:
+        List of theme dicts with friendly field names.
+
+    Raises:
+        ValueError: If status is not a valid theme status.
+    """
+    params = {"context": "edit"}
+    if status:
+        if status not in THEME_STATUSES:
+            raise ValueError(
+                f"Invalid status '{status}'. "
+                f"Valid statuses: {', '.join(THEME_STATUSES)}"
+            )
+        params["status"] = status
+    data = client.get("themes", params=params)
+    if not isinstance(data, list):
+        return []
+    return [_extract_theme_row(t) for t in data]
+
+
+def get_theme(client, stylesheet):
+    """Get a single installed theme by stylesheet (e.g. 'twentytwentyfive')."""
+    endpoint = _theme_endpoint(stylesheet)
+    data = client.get(endpoint, params={"context": "edit"})
+    return _extract_theme_row(data)


### PR DESCRIPTION
PR 2 of 4 for the v0.11.0 milestone (Phase 7: introspection).

- `wpa block list/get` — /wp/v2/block-types, `--namespace` filter, namespaced `get` names split and per-segment validated (closes #71)
- `wpa theme list/get` — /wp/v2/themes read-only, `--status` filter, {raw, rendered} objects flattened, subdirectory stylesheets supported (closes #73)

TDD: 28 new tests written first (677 total, 98% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia