### PR TITLE
feat: api discover — REST surface enumeration (#72)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -962,3 +962,57 @@ class TestConfigurableCaps:
 
         list(client.get_list("posts"))
         assert mock_get.call_count == 3
+
+
+class TestGetRoot:
+    @patch("wpa.api.requests.request")
+    def test_get_root_url(self, mock_request, client):
+        resp = MagicMock()
+        resp.ok = True
+        resp.content = b'{"namespaces": ["wp/v2"]}'
+        resp.json.return_value = {"namespaces": ["wp/v2"]}
+        mock_request.return_value = resp
+
+        result = client.get_root()
+        assert result == {"namespaces": ["wp/v2"]}
+        args, _kwargs = mock_request.call_args
+        assert args == ("GET", "https://example.com/wp-json/")
+
+    @patch("wpa.api.requests.request")
+    def test_get_root_passes_params(self, mock_request, client):
+        resp = MagicMock()
+        resp.ok = True
+        resp.content = b"{}"
+        resp.json.return_value = {}
+        mock_request.return_value = resp
+
+        client.get_root(params={"_fields": "namespaces"})
+        _, kwargs = mock_request.call_args
+        assert kwargs["params"] == {"_fields": "namespaces"}
+
+    @patch("wpa.api.requests.request")
+    def test_get_root_is_authenticated(self, mock_request, client):
+        resp = MagicMock()
+        resp.ok = True
+        resp.content = b"{}"
+        resp.json.return_value = {}
+        mock_request.return_value = resp
+
+        client.get_root()
+        _, kwargs = mock_request.call_args
+        assert "Authorization" in kwargs["headers"]
+
+    @patch("wpa.api.requests.request")
+    def test_get_root_size_cap_enforced(self, mock_request, client, monkeypatch):
+        monkeypatch.setenv("WPA_MAX_RESPONSE_BYTES", "10")
+
+        resp = MagicMock()
+        resp.ok = True
+        resp.status_code = 200
+        resp.url = "https://example.com/wp-json/"
+        resp.content = b"x" * 100
+        mock_request.return_value = resp
+
+        with pytest.raises(WPApiError) as exc_info:
+            client.get_root()
+        assert exc_info.value.code == "response_too_large"

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,123 @@
+"""Tests for wpa.discover — REST API surface discovery."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wpa.discover import (
+    NAMESPACE_AVAILABLE_FIELDS,
+    NAMESPACE_DEFAULT_FIELDS,
+    ROUTE_AVAILABLE_FIELDS,
+    ROUTE_DEFAULT_FIELDS,
+    list_namespaces,
+    list_routes,
+    validate_namespace_fields,
+    validate_route_fields,
+)
+
+SAMPLE_ROOT_NAMESPACES = {
+    "namespaces": ["oembed/1.0", "wp/v2", "wp-site-health/v1"],
+}
+
+SAMPLE_ROOT_ROUTES = {
+    "routes": {
+        "/wp/v2/posts": {
+            "namespace": "wp/v2",
+            "methods": ["GET", "POST"],
+        },
+        "/wp/v2/posts/(?P<id>[\\d]+)": {
+            "namespace": "wp/v2",
+            "methods": ["GET", "POST", "PUT", "PATCH", "DELETE"],
+        },
+        "/oembed/1.0/embed": {
+            "namespace": "oembed/1.0",
+            "methods": ["GET"],
+        },
+    },
+}
+
+
+@pytest.fixture
+def mock_client():
+    return MagicMock()
+
+
+class TestValidateFields:
+    def test_namespace_none_returns_defaults(self):
+        assert validate_namespace_fields(None) == NAMESPACE_DEFAULT_FIELDS
+
+    def test_namespace_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_namespace_fields("bogus")
+
+    def test_route_none_returns_defaults(self):
+        assert validate_route_fields(None) == ROUTE_DEFAULT_FIELDS
+
+    def test_route_valid_fields_parsed(self):
+        assert validate_route_fields("route,methods") == ["route", "methods"]
+
+    def test_route_unknown_field_raises(self):
+        with pytest.raises(ValueError, match="Unknown field"):
+            validate_route_fields("route,bogus")
+
+    def test_defaults_are_available(self):
+        for f in NAMESPACE_DEFAULT_FIELDS:
+            assert f in NAMESPACE_AVAILABLE_FIELDS
+        for f in ROUTE_DEFAULT_FIELDS:
+            assert f in ROUTE_AVAILABLE_FIELDS
+
+
+class TestListNamespaces:
+    def test_list_success(self, mock_client):
+        mock_client.get_root.return_value = SAMPLE_ROOT_NAMESPACES
+        rows = list_namespaces(mock_client)
+        assert [r["namespace"] for r in rows] == [
+            "oembed/1.0",
+            "wp-site-health/v1",
+            "wp/v2",
+        ]
+        mock_client.get_root.assert_called_once_with(params={"_fields": "namespaces"})
+
+    def test_non_dict_response_returns_empty(self, mock_client):
+        mock_client.get_root.return_value = ["unexpected"]
+        assert list_namespaces(mock_client) == []
+
+    def test_missing_namespaces_returns_empty(self, mock_client):
+        mock_client.get_root.return_value = {}
+        assert list_namespaces(mock_client) == []
+
+    def test_non_string_entries_skipped(self, mock_client):
+        mock_client.get_root.return_value = {"namespaces": ["wp/v2", 42]}
+        rows = list_namespaces(mock_client)
+        assert [r["namespace"] for r in rows] == ["wp/v2"]
+
+
+class TestListRoutes:
+    def test_list_success(self, mock_client):
+        mock_client.get_root.return_value = SAMPLE_ROOT_ROUTES
+        rows = list_routes(mock_client)
+        assert len(rows) == 3
+        assert rows[0]["route"] == "/oembed/1.0/embed"
+        assert rows[0]["methods"] == "GET"
+        assert rows[1]["namespace"] == "wp/v2"
+        mock_client.get_root.assert_called_once_with(params={"_fields": "routes"})
+
+    def test_namespace_filter(self, mock_client):
+        mock_client.get_root.return_value = SAMPLE_ROOT_ROUTES
+        rows = list_routes(mock_client, namespace="oembed/1.0")
+        assert [r["route"] for r in rows] == ["/oembed/1.0/embed"]
+
+    def test_methods_joined_sorted_routes(self, mock_client):
+        mock_client.get_root.return_value = SAMPLE_ROOT_ROUTES
+        rows = list_routes(mock_client)
+        assert rows[2]["methods"] == "GET, POST, PUT, PATCH, DELETE"
+
+    def test_non_dict_response_returns_empty(self, mock_client):
+        mock_client.get_root.return_value = None
+        assert list_routes(mock_client) == []
+
+    def test_non_dict_route_values_skipped(self, mock_client):
+        mock_client.get_root.return_value = {
+            "routes": {"/wp/v2/posts": "not-an-object"}
+        }
+        assert list_routes(mock_client) == []

--- a/wpa/api.py
+++ b/wpa/api.py
@@ -393,6 +393,24 @@ class WPApiClient:
         """
         return self._request("GET", self._url(endpoint), params=params)
 
+    def get_root(self, params=None):
+        """GET the REST API root index (/wp-json/).
+
+        The root index lives outside the wp/v2 namespace, so this is the
+        one request that bypasses _url(). The URL is fixed — no
+        user-supplied path segments are involved — and the request still
+        goes through _request(), so auth, the response-size cap, the
+        TLS-downgrade check, and WAF detection all apply.
+
+        Args:
+            params: Optional query parameters (e.g. {'_fields': 'routes'}
+                to keep the potentially large index response small).
+
+        Returns:
+            Parsed JSON response dict.
+        """
+        return self._request("GET", f"{self.site_url}/wp-json/", params=params)
+
     def get_total(self, endpoint, params=None):
         """Return the total number of items in a collection.
 

--- a/wpa/cli.py
+++ b/wpa/cli.py
@@ -33,6 +33,12 @@ from wpa.comment import (
     validate_fields as validate_comment_fields,
 )
 from wpa.config import create_site_config, list_sites
+from wpa.discover import (
+    list_namespaces,
+    list_routes,
+    validate_namespace_fields,
+    validate_route_fields,
+)
 from wpa.exceptions import WPApiError, WPConnectionError, WPTimeoutError
 from wpa.formatter import format_count, format_field, format_ids, format_output
 from wpa.media import (
@@ -852,6 +858,26 @@ def _do_media_delete(args):  # pragma: no cover
 
 
 # --- Comment handlers ---
+
+
+def _do_api_discover(args):  # pragma: no cover
+    """Show the namespaces (or routes) a site's REST API exposes."""
+    try:
+        client = WPApiClient.from_config(site_name=args.site, debug=args.debug)
+        if args.routes:
+            fields = validate_route_fields(args.fields)
+            rows = list_routes(client, namespace=args.namespace)
+        else:
+            if args.namespace:
+                raise ValueError("--namespace requires --routes.")
+            fields = validate_namespace_fields(args.fields)
+            rows = list_namespaces(client)
+        return _format_list_output(rows, fields, args)
+    except ValueError as e:
+        print(f"Error: {e}")
+        return 1
+    except (WPApiError, WPConnectionError, WPTimeoutError) as e:
+        return _handle_api_error(e)
 
 
 def _do_block_list(args):  # pragma: no cover
@@ -2134,6 +2160,30 @@ def main(argv=None):
     )
     post_type_get_parser.set_defaults(func=_do_post_type_get)
 
+    # --- wpa api ---
+    api_parser = subparsers.add_parser(
+        "api",
+        help="REST API discovery commands",
+    )
+    api_subparsers = api_parser.add_subparsers(dest="api_command")
+
+    # wpa api discover
+    api_discover_parser = api_subparsers.add_parser(
+        "discover",
+        parents=[shared, list_p],
+        help="Enumerate the namespaces and routes a site's REST API exposes",
+    )
+    api_discover_parser.add_argument(
+        "--routes",
+        action="store_true",
+        help="List individual routes with their methods instead of namespaces",
+    )
+    api_discover_parser.add_argument(
+        "--namespace",
+        help="With --routes, only show routes in this namespace (e.g. wp/v2)",
+    )
+    api_discover_parser.set_defaults(func=_do_api_discover)
+
     # --- wpa block ---
     block_parser = subparsers.add_parser(
         "block",
@@ -2760,6 +2810,12 @@ def main(argv=None):
         args, "post_type_command", None
     ):  # pragma: no cover
         post_type_parser.print_help()
+        return 1
+
+    if args.command == "api" and not getattr(
+        args, "api_command", None
+    ):  # pragma: no cover
+        api_parser.print_help()
         return 1
 
     if args.command == "block" and not getattr(

--- a/wpa/discover.py
+++ b/wpa/discover.py
@@ -1,0 +1,96 @@
+"""REST API surface discovery via the /wp-json/ root index.
+
+`wpa api discover` shows what a site actually exposes: which namespaces
+are registered (core, plugins) and, with --routes, every route and its
+methods. Useful for diagnosing which wpa commands a site can support —
+block themes, disabled endpoints, or WAF filtering all show up here.
+
+The root index is fetched with `_fields` narrowing so only the requested
+section (namespaces or routes) crosses the wire; the client's response
+size cap still applies.
+"""
+
+NAMESPACE_FIELDS = ["namespace"]
+ROUTE_FIELDS = ["route", "namespace", "methods"]
+
+NAMESPACE_AVAILABLE_FIELDS = list(NAMESPACE_FIELDS)
+NAMESPACE_DEFAULT_FIELDS = list(NAMESPACE_FIELDS)
+
+ROUTE_AVAILABLE_FIELDS = list(ROUTE_FIELDS)
+ROUTE_DEFAULT_FIELDS = list(ROUTE_FIELDS)
+
+
+def _validate(fields_str, available, defaults):
+    if fields_str is None:
+        return defaults
+    fields = [f.strip() for f in fields_str.split(",")]
+    for field in fields:
+        if field not in available:
+            raise ValueError(
+                f"Unknown field '{field}'. Available fields: {', '.join(available)}"
+            )
+    return fields
+
+
+def validate_namespace_fields(fields_str):
+    """Validate a --fields string for namespace listings."""
+    return _validate(fields_str, NAMESPACE_AVAILABLE_FIELDS, NAMESPACE_DEFAULT_FIELDS)
+
+
+def validate_route_fields(fields_str):
+    """Validate a --fields string for route listings."""
+    return _validate(fields_str, ROUTE_AVAILABLE_FIELDS, ROUTE_DEFAULT_FIELDS)
+
+
+def list_namespaces(client):
+    """Fetch the namespaces registered on a site.
+
+    Args:
+        client: WPApiClient instance.
+
+    Returns:
+        List of {'namespace': str} rows, sorted.
+    """
+    data = client.get_root(params={"_fields": "namespaces"})
+    if not isinstance(data, dict):
+        return []
+    namespaces = data.get("namespaces", [])
+    if not isinstance(namespaces, list):
+        return []
+    names = sorted(ns for ns in namespaces if isinstance(ns, str))
+    return [{"namespace": ns} for ns in names]
+
+
+def list_routes(client, namespace=None):
+    """Fetch the routes a site exposes, optionally scoped to one namespace.
+
+    Args:
+        client: WPApiClient instance.
+        namespace: Namespace to filter by (e.g. 'wp/v2'), or None for all.
+
+    Returns:
+        List of {'route', 'namespace', 'methods'} rows, sorted by route.
+    """
+    data = client.get_root(params={"_fields": "routes"})
+    if not isinstance(data, dict):
+        return []
+    routes = data.get("routes", {})
+    if not isinstance(routes, dict):
+        return []
+
+    rows = []
+    for route in sorted(routes):
+        info = routes[route]
+        if not isinstance(info, dict):
+            continue
+        if namespace and info.get("namespace") != namespace:
+            continue
+        methods = info.get("methods", [])
+        rows.append(
+            {
+                "route": route,
+                "namespace": info.get("namespace", ""),
+                "methods": ", ".join(str(m) for m in methods),
+            }
+        )
+    return rows


### PR DESCRIPTION
PR 3 of 4 for the v0.11.0 milestone (Phase 7: introspection).

- `wpa api discover` — namespaces listing (closes #72)
- `wpa api discover --routes [--namespace wp/v2]` — routes with methods

Contains the release's only shared-client change: `WPApiClient.get_root()`, a fixed-URL GET of `/wp-json/` (no user-supplied path segments) that still goes through `_request()`, so auth, the response-size cap, the TLS-downgrade check, and WAF detection all apply. `_fields` narrowing keeps the index response small.

TDD: 19 new tests written first (696 total, 98% coverage). One caught a real crash — mixed-type namespace arrays broke `sorted()` before non-strings were filtered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia