### PR TITLE
release: v0.11.0 — Phase 7 introspection and discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ CI runs on ubuntu/macos/windows across Python 3.10, 3.11, 3.12, 3.13, plus a wee
 
 ## Architecture
 
-**Entry point**: `wpa/cli.py` — argparse-based CLI with subcommands (`publish`, `post list/get/create/update/delete`, `page list/get/create/update/delete`, `site add/list`, `user list/get/create/update/delete/set-role`, `media list/get/import/delete`, `comment list/get/create/update/delete/approve/unapprove/spam/unspam/trash/count`, `term list/get/create/update/delete` plus `category`/`tag` aliases, `plugin list/get/activate/deactivate`, `menu list/get/create/delete` with `item` and `location` sub-groups, `widget list/get/update/deactivate/delete`, `option list/get/update`, `sidebar list`).
+**Entry point**: `wpa/cli.py` — argparse-based CLI with subcommands (`publish`, `post list/get/create/update/delete`, `page list/get/create/update/delete`, `site add/list`, `user list/get/create/update/delete/set-role`, `media list/get/import/delete`, `comment list/get/create/update/delete/approve/unapprove/spam/unspam/trash/count`, `term list/get/create/update/delete` plus `category`/`tag` aliases, `plugin list/get/activate/deactivate`, `menu list/get/create/delete` with `item` and `location` sub-groups, `widget list/get/update/deactivate/delete`, `option list/get/update`, `sidebar list`, `taxonomy list/get`, `post-type list/get`, `block list/get`, `theme list/get`, `api discover`).
 
 **Modules**:
 - `cli.py` — Command parsing, dispatches to other modules
@@ -51,11 +51,15 @@ CI runs on ubuntu/macos/windows across Python 3.10, 3.11, 3.12, 3.13, plus a wee
 - `widget.py` — Classic widget management against `/wp-json/wp/v2/widgets`. `list`/`get` (status synthesized from sidebar; `get` flattens instance settings), `update` (move and/or `--instance-json`), `deactivate` (move to `wp_inactive_widgets`), `delete` (default parks inactive, `--force` removes). No `widget add` — per-type instance schemas
 - `option.py` — Registered-settings management against `/wp-json/wp/v2/settings` (single object, not a collection). `list`/`get`/`update` with JSON-typed value parsing; existence-checked before writes so unknown names get the `show_in_rest` explanation
 - `sidebar.py` — Read-only sidebar listing against `/wp-json/wp/v2/sidebars`
+- `taxonomy.py` / `post_type.py` — Read-only introspection of `/wp-json/wp/v2/{taxonomies,types}`. Both endpoints return slug-keyed objects (not arrays, not paginated); rows synthesized and sorted by slug
+- `block.py` — Read-only block-type introspection against `/wp-json/wp/v2/block-types`. `list --namespace` scopes; `get` takes namespaced names (`core/paragraph`) split into two `build_endpoint`-validated segments
+- `theme.py` — Read-only theme info against `/wp-json/wp/v2/themes`. `--status` filter; stylesheets capped at two segments (`parent/child`). Listing all themes requires `switch_themes`
+- `discover.py` — REST surface discovery via the `/wp-json/` root index (`api discover`). Uses `WPApiClient.get_root()` — the one fixed-URL request outside the wp/v2 prefix, still flowing through `_request()` so all client guards apply; `_fields` narrowing keeps responses small
 - `formatter.py` — Shared output formatting (table, json, csv, tsv) with column selection via `--fields`, plus `--ids`, `--count`, `--field` output modifiers
 
 **Global flags**: `--debug` (HTTP request/response details) available on all commands. `--site` selects a named site config.
 
-**Tests**: All in `tests/` (626 tests), use `unittest.mock` to mock HTTP requests. No live WordPress connection needed.
+**Tests**: All in `tests/` (697 tests), use `unittest.mock` to mock HTTP requests. No live WordPress connection needed.
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,51 @@ wpa term delete 7 --site mysite --taxonomy category
 
 **Note on `delete`:** The WordPress REST API does not support trashing taxonomy terms, so `wpa term delete` (and the `category` / `tag` aliases) always performs a permanent delete. There is no `--force` flag — force is implicit.
 
+### Inspect site structure (taxonomies, post types, blocks)
+
+```bash
+# Which taxonomies does this site register? (shows what --taxonomy accepts)
+wpa taxonomy list --site mysite
+wpa taxonomy get category --site mysite
+
+# Registered post types
+wpa post-type list --site mysite
+wpa post-type get post --site mysite --format json
+
+# Registered block types (sites register hundreds; scope with --namespace)
+wpa block list --site mysite --namespace core
+wpa block get core/paragraph --site mysite
+```
+
+All read-only.
+
+### Discover a site's REST API surface
+
+```bash
+# Which API namespaces does the site expose? (core, plugins, ...)
+wpa api discover --site mysite
+
+# Every route with its methods, optionally scoped to a namespace
+wpa api discover --site mysite --routes
+wpa api discover --site mysite --routes --namespace wp/v2
+```
+
+Useful for diagnosing what a site actually supports — disabled endpoints,
+WAF filtering, and plugin APIs all show up here.
+
+### View themes
+
+```bash
+# List installed themes (listing all requires switch_themes capability)
+wpa theme list --site mysite
+wpa theme list --site mysite --status active
+
+# Get one theme by stylesheet
+wpa theme get twentytwentyfive --site mysite
+```
+
+Read-only — the REST API does not expose theme activation or installation.
+
 ### Output options
 
 All list commands support these output modifiers:

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,78 @@
 # Release Notes
 
+## v0.11.0 — Phase 7: Introspection and Discovery (2026-08-10)
+
+Four read-only command groups plus API surface discovery — PRD Phase 7.
+Where earlier releases managed a site's content and structure, this one
+lets you *ask a site what it is*: which taxonomies, post types, and
+blocks it registers, which themes are installed, and which REST routes
+it actually exposes.
+
+On PyPI as [wpa 0.11.0](https://pypi.org/project/wpa/0.11.0/) —
+`pip install --upgrade wpa`.
+
+### `wpa taxonomy` / `wpa post-type` (#69, #70)
+
+```bash
+wpa taxonomy list                 # which slugs does `term --taxonomy` accept here?
+wpa taxonomy get category
+wpa post-type list
+wpa post-type get post --format json
+```
+
+Both REST endpoints return slug-keyed objects (not arrays, not
+paginated); rows are synthesized and sorted by slug.
+
+### `wpa block` (#71)
+
+```bash
+wpa block list --namespace core   # sites register hundreds — scope the listing
+wpa block get core/paragraph
+```
+
+Block names are namespaced; `get` validates each path segment
+independently.
+
+### `wpa theme` (#73)
+
+```bash
+wpa theme list --status active    # listing ALL themes requires switch_themes
+wpa theme get twentytwentyfive
+```
+
+Read-only by REST API design — activation and installation are not
+exposed. Subdirectory stylesheets (`parent/child`) are supported, capped
+at two segments.
+
+### `wpa api discover` (#72)
+
+```bash
+wpa api discover                  # namespaces: core, plugins, ...
+wpa api discover --routes --namespace wp/v2
+```
+
+Enumerates what a site's REST API actually exposes — the fastest way to
+diagnose disabled endpoints, WAF filtering, or which wpa commands a
+given site can support. Backed by the new `WPApiClient.get_root()`, the
+release's only shared-client change: a fixed-URL GET of `/wp-json/`
+that keeps every client guard (auth, response-size cap, TLS-downgrade
+check, WAF detection) and uses `_fields` narrowing to keep the large
+root index response small.
+
+### Release audit and process
+
+The three-lens release audit (new in the workflow this release) caught
+one hardening gap fixed here — theme stylesheet paths accepted unbounded
+segments; now capped at two — and filed #79 (full-object JSON output for
+`get` commands) and #75 (bare group commands crash instead of printing
+help; the two new groups in this release ship with guards).
+
+`wpa user application-password` (#74), the remaining Phase 7
+deliverable, is deliberately deferred to its own small release so the
+credential-bearing flow gets an undiluted security audit.
+
+697 tests, 98% coverage. All new commands are read-only.
+
 ## v0.10.0 — Phase 6: Plugins, Menus, Widgets, Settings (2026-08-09)
 
 Five new command groups covering PRD Phase 6 — the site-structure tier of

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -114,3 +114,10 @@ class TestGetTheme:
         with pytest.raises(ValueError, match="Invalid theme stylesheet"):
             get_theme(mock_client, "")
         mock_client.get.assert_not_called()
+
+    def test_too_many_segments_raises(self, mock_client):
+        # Stylesheets are at most parent/child (subdirectory themes);
+        # anything deeper is not a real theme path.
+        with pytest.raises(ValueError, match="Invalid theme stylesheet"):
+            get_theme(mock_client, "a/b/c")
+        mock_client.get.assert_not_called()

--- a/wpa-prd.md
+++ b/wpa-prd.md
@@ -1,10 +1,10 @@
 # WPA — Product Requirements Document
 
 **Product:** WPA (WordPress Automation)
-**Version:** PRD v1.4
-**Date:** 2026-08-09
+**Version:** PRD v1.5
+**Date:** 2026-08-10
 **Author:** Neil Johnson, Cadent Creative
-**Current release:** v0.10.0
+**Current release:** v0.11.0
 **Repository:** [github.com/cadentdev/wpa](https://github.com/cadentdev/wpa)
 **PyPI:** [pypi.org/project/wpa](https://pypi.org/project/wpa/)
 **License:** MIT
@@ -163,6 +163,11 @@ wpa/
 ├── widget.py       # Widget subcommand handlers
 ├── option.py       # Settings/option subcommand handlers
 ├── sidebar.py      # Sidebar subcommand handlers
+├── taxonomy.py     # Taxonomy introspection (read-only)
+├── post_type.py    # Post type introspection (read-only)
+├── block.py        # Block type introspection (read-only)
+├── theme.py        # Theme information (read-only)
+├── discover.py     # REST API surface discovery (/wp-json/ root index)
 ├── formatter.py    # Output formatting (table, JSON, CSV, TSV)
 └── __init__.py     # Package version (single source, read by pyproject)
 ```
@@ -233,7 +238,7 @@ These are the quality bars every release meets (folded in from the retired devel
 
 ## 6. Command structure
 
-### 6.1 Implemented commands (v0.10.0)
+### 6.1 Implemented commands (v0.11.0)
 
 **Content publishing**
 
@@ -341,6 +346,22 @@ These are the quality bars every release meets (folded in from the retired devel
 |---|---|
 | `wpa sidebar list` | Read-only listing of registered sidebars |
 
+**Introspection** (Tier 4, shipped v0.11.0; all read-only)
+
+| Command | Description |
+|---|---|
+| `wpa taxonomy list/get` | Registered taxonomies — shows which slugs `wpa term --taxonomy` accepts on a site |
+| `wpa post-type list/get` | Registered post types |
+| `wpa block list/get` | Registered block types. `--namespace` scopes the listing; `get` takes namespaced names (`core/paragraph`) |
+| `wpa api discover` | Namespaces a site's REST API registers; `--routes [--namespace]` lists routes with methods. Diagnoses what a site actually exposes (disabled endpoints, WAF filtering, plugin APIs) |
+
+**Themes** (Tier 5, shipped v0.11.0; read-only)
+
+| Command | Description |
+|---|---|
+| `wpa theme list` | Installed themes with `--status active/inactive/all`. Listing all requires `switch_themes` |
+| `wpa theme get <stylesheet>` | Single theme; subdirectory stylesheets (`parent/child`) supported. Activation/install not exposed by the REST API |
+
 **Site configuration**
 
 | Command | Description |
@@ -357,24 +378,19 @@ These are the quality bars every release meets (folded in from the retired devel
 
 ### 6.2 Planned command groups
 
-Based on the REST API mapping matrix, the following command groups are implementable and prioritized by value. (Tiers 1–3 — posts, pages, users, media, comments, terms, plugins, menus, widgets, settings, and sidebars — shipped in v0.6.0–v0.10.0 and are documented in §6.1. Plugin `install`/`delete` remain open as #41 follow-ups.)
+Based on the REST API mapping matrix, the following command groups are implementable and prioritized by value. (Tiers 1–4 plus themes — posts, pages, users, media, comments, terms, plugins, menus, widgets, settings, sidebars, introspection, and themes — shipped in v0.6.0–v0.11.0 and are documented in §6.1. Plugin `install`/`delete` remain open as #41 follow-ups.)
 
-**Tier 4 — Introspection and discovery**
+**Tier 4 — remaining**
 
 | Command Group | Key Subcommands | REST API Endpoint |
 |---|---|---|
-| `wpa taxonomy` | `list`, `get` | `/wp/v2/taxonomies` |
-| `wpa post-type` | `list`, `get` | `/wp/v2/types` |
-| `wpa block` | `list`, `get` | `/wp/v2/block-types` |
 | `wpa ability` | `list`, `get`, `run` | `/wp/v2/abilities` |
-| `wpa api discover` | List all available REST API endpoints for a site | `GET /wp-json/` |
 
 **Tier 5 — User security management**
 
 | Command Group | Key Subcommands | REST API Endpoint |
 |---|---|---|
-| `wpa user application-password` | `list`, `create`, `delete`, `get` | `/wp/v2/users/<id>/application-passwords` |
-| `wpa theme` | `list`, `get`, `is-active` (read-only) | `/wp/v2/themes` |
+| `wpa user application-password` | `list`, `create`, `delete`, `get` | `/wp/v2/users/<id>/application-passwords` — scoped to its own release (#74) so the credential-bearing flow gets an undiluted audit |
 
 ### 6.3 Global flags
 
@@ -479,16 +495,22 @@ Shipped in v0.8.0 (2026-04-15). See `RELEASE-NOTES.md` for full notes including 
 | `wpa sidebar list` | Shipped v0.10.0 |
 | `wpa option get/update/list` | Shipped v0.10.0 |
 
-### Phase 7: Introspection and discovery (v0.11.0)
+### Phase 7: Introspection and discovery (v0.11.0) — COMPLETE
 
 | Deliverable | Details |
 |---|---|
-| `wpa taxonomy list/get` | List/inspect registered taxonomies |
-| `wpa post-type list/get` | List/inspect registered post types |
-| `wpa block list/get` | List/inspect registered block types |
-| `wpa api discover` | Enumerate all REST API endpoints and their methods for a site |
-| `wpa theme list/get` | Read-only theme information |
-| `wpa user application-password` | Manage application passwords for users |
+| `wpa taxonomy list/get` | Shipped v0.11.0 |
+| `wpa post-type list/get` | Shipped v0.11.0 |
+| `wpa block list/get` | Shipped v0.11.0 (`--namespace` scoping; namespaced `get` names) |
+| `wpa api discover` | Shipped v0.11.0 (namespaces default, `--routes` for full surface) |
+| `wpa theme list/get` | Shipped v0.11.0 (read-only; REST API exposes no activation/install) |
+| `wpa user application-password` | Deferred to its own release (#74) — credential-bearing work gets a small, sharply-audited release per the workflow size gate |
+
+### Phase 7.5: Application passwords (v0.12.0)
+
+| Deliverable | Details |
+|---|---|
+| `wpa user application-password list/create/delete` | #74 — one-time password display, `--debug` redaction, output-format safety |
 
 ### Phase 8: Polish and 1.0 (v1.0.0)
 

--- a/wpa/__init__.py
+++ b/wpa/__init__.py
@@ -1,3 +1,3 @@
 """WordPress Automation — manage posts, pages, and users via the REST API."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/wpa/theme.py
+++ b/wpa/theme.py
@@ -73,7 +73,7 @@ def _theme_endpoint(stylesheet):
     via build_endpoint.
     """
     parts = stylesheet.split("/") if stylesheet else []
-    if not parts or not all(parts):
+    if not parts or len(parts) > 2 or not all(parts):
         raise ValueError(f"Invalid theme stylesheet: {stylesheet!r}")
     try:
         return build_endpoint("themes", *parts)


### PR DESCRIPTION
PR 4 of 4 for the v0.11.0 milestone. Closes out the release:

**Audit (3-lens, per workflow step 7):**
- Lens (a) round-trip symmetry: clean — every command this release is read-only.
- Lens (b) type boundaries: one finding, fixed here test-first — theme stylesheet paths accepted unbounded segments, now capped at two (`parent/child` max, mirroring the plugin identifier cap).
- Lens (c) classic pass: clean — `get_root()` keeps all client guards; every user-supplied path segment goes through `build_endpoint`.
- Filed from audit: #79 (get commands flatten JSON output), plus #75 earlier (bare group commands crash).

**Regression:** 697 tests, 98% coverage; ruff/bandit clean; pip-audit clean on project deps.

**Docs:** PRD → v1.5 (Phase 7 COMPLETE; #74 application-passwords deferred to Phase 7.5/v0.12.0 per the size gate), README usage sections for all five groups, CLAUDE.md architecture + test count, RELEASE-NOTES v0.11.0 section.

**Version:** 0.11.0 (single source, `wpa/__init__.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LmtenXeekXtPa2bda39Lia