### PR TITLE
chore: correct package author metadata to Neil Johnson

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    {name = "Neil Stoker"},
+    {name = "Neil Johnson"},
 ]
 keywords = ["wordpress", "cli", "markdown", "publishing", "automation"]
 classifiers = [


### PR DESCRIPTION
Corrects the author name/email in `pyproject.toml`.

- `wpa`, `iname`, `ipro` carried the wrong author **name** (`Neil Stoker`)
- `pagepull`, `xplat`, `sitecheck`, `website-crawler` carried the wrong email **domain** (`cadent.com` → `cadent.net`)
- `ansible` still had the template placeholder (`Your Name <your.email@example.com>`)

One line changed, no functional impact.

**Note:** published PyPI metadata is frozen per release. `wpa` 0.11.0, `iname` 0.1.0 and
`ipro-cli` 1.6.0 will keep displaying the old author until a new version is uploaded.

— SAM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br6JDQ2Y58GXPg72rND8vD